### PR TITLE
docs: display GUIDELINES.md in storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,10 @@
 /** @type { import('@storybook/react-vite').StorybookConfig } */
 const config = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: [
+    "../stories/**/*.mdx",
+    "../src/**/*.mdx",
+    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+  ],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -4,7 +4,7 @@
 
 The primary goal of this library is to address the issue of duplicated React components across MAAS UI projects and encourage better component design and separation of concerns.
 
-It is not meant to be a replacement for @canonical/react-components.
+It is not meant to be a replacement for [@canonical/react-components](https://github.com/canonical/react-components).
 
 This library contains either components that are specific to, or only used in MAAS, such as components not yet approved by the design team for wide use across all web team sites and applications. General purpose components should be added to @canonical/react-components and not @canonical/maas-react-components.
 

--- a/stories/Readme.stories.mdx
+++ b/stories/Readme.stories.mdx
@@ -1,0 +1,21 @@
+import GUIDELINES from "../GUIDELINES.md?raw";
+
+import { Markdown } from "@storybook/blocks";
+import { Meta } from "@storybook/addon-docs/blocks";
+import { DocsContainer } from "@storybook/blocks";
+import { name, description } from "../package.json";
+
+<Meta title="Readme" />
+
+<img
+  src="https://assets.ubuntu.com/v1/142ae045-Canonical%20MAAS.png"
+  alt="Canonical MAAS"
+  width="180"
+/>
+<br />
+
+<h1>{name}</h1>
+
+<p>{description}</p>
+
+<Markdown>{GUIDELINES}</Markdown>


### PR DESCRIPTION
## Done
- docs: display GUIDELINES.md in storybook as a landing page

<!--
- Itemised list of what was changed by this PR.
-->

<!-- Steps for QA. -->

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

![Google Chrome screenshot 000994@2x](https://github.com/canonical/maas-react-components/assets/7452681/ba371aed-0031-478e-9f5b-97e619f6fa40)




## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
