### PR TITLE
docs: remove default storybook styles

### DIFF
--- a/.storybook/DocumentationTemplate.mdx
+++ b/.storybook/DocumentationTemplate.mdx
@@ -1,12 +1,15 @@
 import {
   Meta,
   Title,
+  Unstyled,
   Subtitle,
   Description,
   Primary,
   Controls,
   Stories,
 } from "@storybook/blocks";
+
+<Unstyled>
 
 <Meta isTemplate />
 
@@ -17,3 +20,5 @@ import {
 ## Props
 
 <Controls />
+
+</Unstyled>

--- a/stories/Readme.stories.mdx
+++ b/stories/Readme.stories.mdx
@@ -1,12 +1,13 @@
 import GUIDELINES from "../GUIDELINES.md?raw";
 
-import { Markdown } from "@storybook/blocks";
+import { Markdown, Unstyled } from "@storybook/blocks";
 import { Meta } from "@storybook/addon-docs/blocks";
 import { DocsContainer } from "@storybook/blocks";
 import { name, description } from "../package.json";
 
 <Meta title="Readme" />
 
+<Unstyled>
 <img
   src="https://assets.ubuntu.com/v1/142ae045-Canonical%20MAAS.png"
   alt="Canonical MAAS"
@@ -14,8 +15,11 @@ import { name, description } from "../package.json";
 />
 <br />
 
-<h1>{name}</h1>
+<p className="p-heading--3">{name}</p>
 
 <p>{description}</p>
+</Unstyled>
 
-<Markdown>{GUIDELINES}</Markdown>
+<Unstyled>
+  <Markdown>{GUIDELINES}</Markdown>
+</Unstyled>


### PR DESCRIPTION
## Done
-  Remove default storybook styles so that vanilla framework styles are applied by default

<!--
- Itemised list of what was changed by this PR.
-->

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
![Google Chrome screenshot 001023@2x](https://github.com/canonical/maas-react-components/assets/7452681/9a838f44-45e3-40e1-8dba-169343dad30a)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
