### PR TITLE
fix: increase specificity of pointer cursor rule

### DIFF
--- a/src/lib/sections/Navigation/Navigation.scss
+++ b/src/lib/sections/Navigation/Navigation.scss
@@ -108,7 +108,9 @@ $side-navigation-z-index: 103;
     .p-side-navigation__link {
       width: 100%;
       justify-content: flex-start;
-  
+    }
+
+    .p-side-navigation__link[aria-current=page] {
       &:hover,:active {
         cursor: pointer;
       }


### PR DESCRIPTION
## Done
- Increased specificity of `cursor: pointer` rule

This was done since there were some conflicts with base vanilla styles, meaning that this did not work in MAAS UI or Site Manager.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Run storybook
- [x] Go to navigation example
- [x] Open dev tools
- [x] Use element selector to select active link
- [x] Toggle hover state to on
- [x] Ensure selector containing rule to set cursor to pointer has specificity of `(0,5,0)`

<!-- Steps for QA. -->
