### PR TITLE
feat: add MainToolbar component

### DIFF
--- a/.storybook/DocumentationTemplate.mdx
+++ b/.storybook/DocumentationTemplate.mdx
@@ -9,16 +9,14 @@ import {
   Stories,
 } from "@storybook/blocks";
 
-<Unstyled>
-
 <Meta isTemplate />
 
 <Title />
+
+<Description />
 
 <Stories />
 
 ## Props
 
 <Controls />
-
-</Unstyled>

--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -1,2 +1,6 @@
 @import "vanilla-framework";
 @include vanilla;
+
+pre {
+  color: #f4f4f4;
+} 

--- a/src/lib/sections/MainToolbar/MainToolbar.scss
+++ b/src/lib/sections/MainToolbar/MainToolbar.scss
@@ -1,0 +1,63 @@
+@import "vanilla-framework";
+
+.main-toolbar {
+  display: flex;
+  container-type: inline-size;
+  column-gap: 1.5rem;
+  align-items: baseline;
+  margin-bottom: $spv--large;
+  flex-direction: row;
+  flex-wrap: wrap;
+  // The negative margin-bottom counteracts the default bottom margin of nested inputs. 
+  // This allows the toolbar to dictate the spacing.
+  margin-bottom: -#{$input-margin-bottom};
+
+  &--stacked {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+.main-toolbar__controls,
+.main-toolbar__controls--observer {
+  display: flex;
+  text-wrap: nowrap;
+  white-space: nowrap;
+  flex-direction: row;
+  column-gap: 1rem;
+  flex: 1;
+
+  &--stacked {
+    flex-wrap: wrap;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  &:not(.main-toolbar__controls--stacked) {
+    justify-content: flex-end;
+  }
+
+  .p-search-and-filter,
+  .debounce-search-box,
+  .p-search-box {
+    flex: 1;
+  }
+
+  // overrides to fix the search box wrapping to the next line
+  .p-search-box {
+    .p-search-box__input {
+      position: static;
+      padding-right: initial;
+    }
+
+    .p-search-box__button {
+      position: absolute;
+    }
+  }
+
+  // Reduce the margin of all direct descendants for consistent spacing
+  > * {
+    margin-right: 0;
+    align-items: baseline;
+  }
+}

--- a/src/lib/sections/MainToolbar/MainToolbar.stories.tsx
+++ b/src/lib/sections/MainToolbar/MainToolbar.stories.tsx
@@ -1,0 +1,50 @@
+import { Button, SearchBox, Select } from "@canonical/react-components";
+import { Meta } from "@storybook/react";
+
+import { MainToolbar } from "@/lib/sections/MainToolbar/MainToolbar";
+
+const meta: Meta<typeof MainToolbar> = {
+  title: "sections/MainToolbar",
+  component: MainToolbar,
+  tags: ["autodocs"],
+  parameters: {
+    status: {
+      type: "candidate",
+    },
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+};
+
+export default meta;
+
+export const Example = {
+  render: () => (
+    <MainToolbar>
+      <MainToolbar.Title>Toolbar title</MainToolbar.Title>
+      <MainToolbar.Controls>
+        <Select
+          options={[
+            {
+              value: "",
+              label: "Filters",
+            },
+          ]}
+        />
+        <SearchBox value="" />
+        <Select
+          options={[
+            {
+              value: "",
+              label: "No grouping",
+            },
+          ]}
+        />
+        <Button appearance="positive">Take action</Button>
+      </MainToolbar.Controls>
+    </MainToolbar>
+  ),
+};

--- a/src/lib/sections/MainToolbar/MainToolbar.test.tsx
+++ b/src/lib/sections/MainToolbar/MainToolbar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { MainToolbar } from ".";
+
+const originalObserver = window.ResizeObserver;
+beforeEach(() => {
+  window.ResizeObserver = vi.fn(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+afterEach(() => {
+  window.ResizeObserver = originalObserver;
+});
+
+test("renders correctly", () => {
+  const title = "Toolbar title";
+  const buttonLabel = "Toolbar button";
+
+  render(
+    <MainToolbar>
+      <MainToolbar.Title>{title}</MainToolbar.Title>
+      <MainToolbar.Controls>
+        <button>{buttonLabel}</button>
+      </MainToolbar.Controls>
+    </MainToolbar>,
+  );
+
+  expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: buttonLabel })).toBeInTheDocument();
+});

--- a/src/lib/sections/MainToolbar/MainToolbar.tsx
+++ b/src/lib/sections/MainToolbar/MainToolbar.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+
+import classNames from "classnames";
+
+import "./MainToolbar.scss";
+
+function useResizeObserver(ref: React.RefObject<HTMLElement>) {
+  const [dimensions, setDimensions] = React.useState<DOMRect | null>(null);
+  const animationFrameId = React.useRef<number | null>(null);
+
+  const updateDimensions = React.useCallback(() => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setDimensions(rect);
+    }
+  }, [ref]);
+
+  React.useEffect(() => {
+    const observer = new ResizeObserver(() => {
+      if (animationFrameId.current) {
+        cancelAnimationFrame(animationFrameId.current);
+      }
+      animationFrameId.current = requestAnimationFrame(updateDimensions);
+    });
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (animationFrameId.current) {
+        cancelAnimationFrame(animationFrameId.current);
+      }
+      observer.disconnect();
+    };
+  }, [ref, updateDimensions]);
+
+  return dimensions;
+}
+
+const RectContext = React.createContext<DOMRect | null>(null);
+const StackContext = React.createContext<
+  [boolean, React.Dispatch<React.SetStateAction<boolean>>]
+>([false, () => {}]);
+
+type MainToolbarProps = {
+  children: React.ReactNode;
+};
+
+/**
+ * A toolbar component for the main content area of the page that automatically adjusts its layout based on available space.
+ *
+ * `MainToolbar` has two child components:
+ * - `MainToolbar.Title`
+ * - `MainToolbar.Controls`
+ *
+ * `MainToolbar.Title` and `MainToolbar.Controls` are wrapped to separate rows using flexbox.
+ * `MainToolbar.Controls` switches to a stacked layout when it overflows the container.
+ */
+export const MainToolbar = ({ children }: MainToolbarProps) => {
+  const ref = React.useRef(null);
+  const rect = useResizeObserver(ref);
+  const [isStacked, setIsStacked] = React.useState(false);
+  return (
+    <header
+      className={classNames("main-toolbar", {
+        "main-toolbar--stacked": isStacked,
+      })}
+      ref={ref}
+    >
+      <RectContext.Provider value={rect}>
+        <StackContext.Provider value={[isStacked, setIsStacked]}>
+          {children}
+        </StackContext.Provider>
+      </RectContext.Provider>
+    </header>
+  );
+};
+
+const MainToolbarTitle = ({ children, ...props }: React.PropsWithChildren) => {
+  return (
+    <h1
+      className="main-toolbar__title p-heading--4"
+      data-testid="main-toolbar-heading"
+      {...props}
+    >
+      {children}
+    </h1>
+  );
+};
+
+const MainToolbarControls = ({ children }: React.PropsWithChildren) => {
+  const rect = React.useContext(RectContext);
+  const [isStacked, setIsStacked] = React.useContext(StackContext);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!ref.current || !rect) {
+      return;
+    }
+    setIsStacked(ref.current.getBoundingClientRect().width > rect.width);
+  }, [setIsStacked, rect, ref]);
+
+  return (
+    <>
+      {/* This hidden clone measures the non-stacked version of the toolbar controls. 
+         It's necessary because we need to know when the full width version fits 
+         while resizing the window up. It's always displayed in the background for comparison. */}
+      <div
+        aria-hidden="true"
+        className="main-toolbar__controls main-toolbar__controls--observer"
+        ref={ref}
+        style={{ visibility: "hidden", position: "absolute" }}
+      >
+        {children}
+      </div>
+      <div
+        className={classNames("main-toolbar__controls", {
+          "main-toolbar__controls--stacked": isStacked,
+        })}
+      >
+        {children}
+      </div>
+    </>
+  );
+};
+
+MainToolbar.Title = MainToolbarTitle;
+MainToolbar.Controls = MainToolbarControls;

--- a/src/lib/sections/MainToolbar/index.ts
+++ b/src/lib/sections/MainToolbar/index.ts
@@ -1,0 +1,1 @@
+export * from "./MainToolbar";

--- a/src/lib/sections/index.ts
+++ b/src/lib/sections/index.ts
@@ -2,3 +2,5 @@ export * from "./Navigation";
 
 export * from "./InputGroup";
 export * from "./FormSection";
+
+export * from "./MainToolbar";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};


### PR DESCRIPTION
## Done
- feat: add MainToolbar component

It automatically adjusts its layout based on available space. `MainToolbar.Title` and `MainToolbar.Controls` are wrapped to separate rows using CSS flexbox.

`MainToolbar.Controls` switches to a stacked layout when it overflows the container. This couldn't be achieved easily using pure CSS. For that reason a non-stacked hidden clone of `MainToolbar.Controls` is always displayed in the background for comparison and measured using `ResizeObserver`.

Designs: https://zpl.io/z8JleKl

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

Repeat in a few different browsers:
- [ ]  Run storybook and go to MainToolbar
- [ ]  Ensure the component is displayed correctly across all breakpoints

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2438](https://warthogs.atlassian.net/browse/MAASENG-2438)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
![Google Chrome screenshot 001155@2x](https://github.com/canonical/maas-react-components/assets/7452681/0ac77ad4-e06b-4f85-b347-eb7e710d1de8)
![Google Chrome screenshot 001157](https://github.com/canonical/maas-react-components/assets/7452681/55154ee7-1922-4cfd-8710-2607a1aab6cf)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2438]: https://warthogs.atlassian.net/browse/MAASENG-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ