### PR TITLE
fix: main toolbar styles specificity

### DIFF
--- a/src/lib/sections/MainToolbar/MainToolbar.scss
+++ b/src/lib/sections/MainToolbar/MainToolbar.scss
@@ -16,48 +16,48 @@
     flex-direction: column;
     align-items: flex-start;
   }
-}
 
-.main-toolbar__controls,
-.main-toolbar__controls--observer {
-  display: flex;
-  text-wrap: nowrap;
-  white-space: nowrap;
-  flex-direction: row;
-  column-gap: 1rem;
-  flex: 1;
-
-  &--stacked {
-    flex-wrap: wrap;
-    flex-direction: column;
-    width: 100%;
-  }
-
-  &:not(.main-toolbar__controls--stacked) {
-    justify-content: flex-end;
-  }
-
-  .p-search-and-filter,
-  .debounce-search-box,
-  .p-search-box {
+  .main-toolbar__controls,
+  .main-toolbar__controls--observer {
+    display: flex;
+    text-wrap: nowrap;
+    white-space: nowrap;
+    flex-direction: row;
+    column-gap: 1rem;
     flex: 1;
-  }
 
-  // overrides to fix the search box wrapping to the next line
-  .p-search-box {
-    .p-search-box__input {
-      position: static;
-      padding-right: initial;
+    &--stacked {
+      flex-wrap: wrap;
+      flex-direction: column;
+      width: 100%;
     }
 
-    .p-search-box__button {
-      position: absolute;
+    &:not(.main-toolbar__controls--stacked) {
+      justify-content: flex-end;
     }
-  }
 
-  // Reduce the margin of all direct descendants for consistent spacing
-  > * {
-    margin-right: 0;
-    align-items: baseline;
+    .p-search-and-filter,
+    .debounce-search-box,
+    .p-search-box {
+      flex: 1;
+    }
+
+    // overrides to fix the search box wrapping to the next line
+    .p-search-box {
+      .p-search-box__input {
+        position: static;
+        padding-right: initial;
+      }
+
+      .p-search-box__button {
+        position: absolute;
+      }
+    }
+
+    // Reduce the margin of all direct descendants for consistent spacing
+    > * {
+      margin-right: 0;
+      align-items: baseline;
+    }
   }
 }


### PR DESCRIPTION
## Done
- fix: main toolbar styles specificity

This increases the specificity of styles by wrapping them in parent class (.main-toolbar) which fixes styling of certain nested elements. This specifically affects reduction of the margin of all direct descendants for consistent spacing.

<!--
- Itemised list of what was changed by this PR.
-->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
