### PR TITLE
fix(MultiSelect): only show selected items that also exist in items array

### DIFF
--- a/src/lib/components/MultiSelect/MultiSelect.tsx
+++ b/src/lib/components/MultiSelect/MultiSelect.tsx
@@ -141,7 +141,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
     onItemsUpdate && onItemsUpdate(uniqueItems);
   };
 
-  const selectedElements = selectedItems.map((item) => (
+  const selectedElements = selectedItems.filter((selectedItem) => items.some(item => item.value === selectedItem.value)).map((item) => (
     <li key={item.value} className="multi-select__selected-item" aria-label={item.label}>
       {item.label}
     </li>


### PR DESCRIPTION
## Done
- Filter items for `selectedElements` to intersection between `items` and `selectedItems`

This is so that multiple `MultiSelect`s can use a shared state, which makes [MAASENG-2541](https://warthogs.atlassian.net/browse/MAASENG-2565) much easier

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Ensure the component is displayed correctly across all breakpoints
- [ ] Either 1) link this repo to another one, or 2) use the story file as a testing area
- [ ] Create 2 MultiSelect components that display different items, but share a selection state
- [ ] Select some items in the first one
- [ ] Ensure that only the first multiselect displays these items
- [ ] Ensure the displayed items match what you selected
- [ ] Select some items in the second one
- [ ] Ensure the selected display does not change in the first one



[MAASENG-2541]: https://warthogs.atlassian.net/browse/MAASENG-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ