### PR TITLE
fix: multiselect overlow

### DIFF
--- a/src/lib/components/MultiSelect/MultiSelect.scss
+++ b/src/lib/components/MultiSelect/MultiSelect.scss
@@ -17,6 +17,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  margin-right: $sph--large + $sph--x-small;
 }
 
 .multi-select__input {
@@ -130,13 +131,17 @@ button.multi-select__select-button {
   z-index: 0;
 
     &::after {
+      position: absolute;
+      right: $sph--small;
+      top: 50%;
+
         @extend %icon;
         @include vf-icon-chevron($color-mid-dark);
         @include vf-transition($property: transform, $duration: fast);
     
         content: '';
         margin-left: $sph--large;
-        transform: rotate(-180deg);
+        transform: translateY(-50%) rotate(-180deg);
       }
 
       &[aria-expanded='true'] {
@@ -145,7 +150,7 @@ button.multi-select__select-button {
     
       &[aria-expanded='false'] {
         &::after {
-          transform: rotate(0);
+          transform: translateY(-50%) rotate(0);
         }
       }
     }

--- a/src/lib/components/MultiSelect/MultiSelect.scss
+++ b/src/lib/components/MultiSelect/MultiSelect.scss
@@ -13,6 +13,12 @@
   margin-top: 0;
 }
 
+.multi-select__condensed-text {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .multi-select__input {
   position: relative;
   cursor: pointer;

--- a/src/lib/components/MultiSelect/MultiSelect.tsx
+++ b/src/lib/components/MultiSelect/MultiSelect.tsx
@@ -228,9 +228,11 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
             onFocus={() => setIsDropdownOpen(true)}
             onClick={() => setIsDropdownOpen(true)}
           >
-            {selectedItems.length > 0
-              ? selectedItemsLabel
-              : placeholder ?? "Select items"}
+            <span className="multi-select__condensed-text">
+              {selectedItems.length > 0
+                ? selectedItemsLabel
+                : placeholder ?? "Select items"}
+            </span>
           </button>
         )}
         <MultiSelectDropdown


### PR DESCRIPTION
## Done
- fix: add multiselect overlow ellipsis

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ]  Ensure the component is displayed correctly across all breakpoints
- [ ] Go to Multiselect condensed variant page
- [ ] Check multiple items until they overflow
- [ ] Verify an ellipsis is displayed

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### After
![Google Chrome screenshot 001448@2x](https://github.com/canonical/maas-react-components/assets/7452681/0ec98536-8aa4-43b6-8e3d-b957a7a01dc2)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
