### PR TITLE
feat: add formatBytes util

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,7 +12,8 @@ const config = {
     "@storybook/addon-a11y",
     "@etchteam/storybook-addon-status",
     "sb-addon-permutation-table",
-    "@storybook/addon-mdx-gfm"
+    "@storybook/addon-mdx-gfm",
+    "storybook-addon-pseudo-states",
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "sb-addon-permutation-table": "^1.0.21",
         "semantic-release": "^22.0.5",
         "storybook": "^7.6.7",
+        "storybook-addon-pseudo-states": "^2.1.2",
         "storybook-addon-tags": "^0.0.1",
         "stylelint": "^15.11.0",
         "stylelint-config-standard-scss": "^11.1.0",
@@ -25431,6 +25432,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-addon-pseudo-states": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-2.1.2.tgz",
+      "integrity": "sha512-AHv6q1JiQEUnMyZE3729iV6cNmBW7bueeytc4Lga4+8W1En8YNea5VjqAdrDNJhXVU0QEEIGtxkD3EoC9aVWLw==",
+      "dev": true,
+      "peerDependencies": {
+        "@storybook/components": "^7.4.6",
+        "@storybook/core-events": "^7.4.6",
+        "@storybook/manager-api": "^7.4.6",
+        "@storybook/preview-api": "^7.4.6",
+        "@storybook/theming": "^7.4.6",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/storybook-addon-tags": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "sb-addon-permutation-table": "^1.0.21",
     "semantic-release": "^22.0.5",
     "storybook": "^7.6.7",
+    "storybook-addon-pseudo-states": "^2.1.2",
     "storybook-addon-tags": "^0.0.1",
     "stylelint": "^15.11.0",
     "stylelint-config-standard-scss": "^11.1.0",

--- a/src/lib/utils/formatBytes/formatBytes.stories.tsx
+++ b/src/lib/utils/formatBytes/formatBytes.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta } from "@storybook/react";
+
+import { formatBytes } from "@/lib/utils";
+import { getUtilStoryComponent } from "@/utils";
+
+const meta: Meta<typeof formatBytes> = {
+  title: "utils/formatBytes",
+  component: getUtilStoryComponent(formatBytes),
+  parameters: {
+    status: {
+      type: "legacy",
+    },
+  },
+};
+
+export default meta;
+export const Example = {
+  args: { value: 1234, unit: "B" },
+};

--- a/src/lib/utils/formatBytes/formatBytes.test.ts
+++ b/src/lib/utils/formatBytes/formatBytes.test.ts
@@ -1,0 +1,160 @@
+import { formatBytes } from "./formatBytes";
+
+it("correctly formats a value above the unit threshold", () => {
+  expect(formatBytes({ value: 900, unit: "KB" })).toStrictEqual({
+    value: 900,
+    unit: "KB",
+  });
+  expect(formatBytes({ value: 1100, unit: "KB" })).toStrictEqual({
+    value: 1.1,
+    unit: "MB",
+  });
+});
+
+it("correctly formats a value below the unit threshold", () => {
+  expect(formatBytes({ value: 1, unit: "MB" })).toStrictEqual({
+    value: 1,
+    unit: "MB",
+  });
+  expect(formatBytes({ value: 0.1, unit: "MB" })).toStrictEqual({
+    value: 100,
+    unit: "KB",
+  });
+});
+
+it("rounds the value to 2 decimal places by default", () => {
+  expect(formatBytes({ value: 1234, unit: "B" })).toStrictEqual({
+    value: 1.23,
+    unit: "KB",
+  });
+  expect(formatBytes({ value: 1236, unit: "B" })).toStrictEqual({
+    value: 1.24,
+    unit: "KB",
+  });
+});
+
+it("can round to different decimal places", () => {
+  expect(
+    formatBytes({ value: 1234, unit: "B" }, { decimals: 0 }),
+  ).toStrictEqual({
+    value: 1,
+    unit: "KB",
+  });
+  expect(
+    formatBytes({ value: 1234, unit: "B" }, { decimals: 1 }),
+  ).toStrictEqual({
+    value: 1.2,
+    unit: "KB",
+  });
+  expect(
+    formatBytes({ value: 1234, unit: "B" }, { decimals: 2 }),
+  ).toStrictEqual({
+    value: 1.23,
+    unit: "KB",
+  });
+  expect(
+    formatBytes({ value: 1234, unit: "B" }, { decimals: 3 }),
+  ).toStrictEqual({
+    value: 1.234,
+    unit: "KB",
+  });
+});
+
+it("can be forced to round result down", () => {
+  expect(
+    formatBytes({ value: 1236, unit: "B" }, { roundFunc: "floor" }),
+  ).toStrictEqual({
+    value: 1.23,
+    unit: "KB",
+  });
+});
+
+it("can be forced to round result up", () => {
+  expect(
+    formatBytes({ value: 1234, unit: "B" }, { roundFunc: "ceil" }),
+  ).toStrictEqual({
+    value: 1.24,
+    unit: "KB",
+  });
+});
+
+it("can handle binary units", () => {
+  expect(formatBytes({ value: 0, unit: "B" }, { binary: true })).toStrictEqual({
+    value: 0,
+    unit: "B",
+  });
+  expect(
+    formatBytes({ value: 1023, unit: "MiB" }, { binary: true }),
+  ).toStrictEqual({
+    value: 1023,
+    unit: "MiB",
+  });
+  expect(
+    formatBytes({ value: 1024, unit: "MiB" }, { binary: true }),
+  ).toStrictEqual({
+    value: 1,
+    unit: "GiB",
+  });
+});
+
+it("can handle negative numbers", () => {
+  expect(formatBytes({ value: -1, unit: "B" })).toStrictEqual({
+    value: -1,
+    unit: "B",
+  });
+  expect(formatBytes({ value: -2000, unit: "MB" })).toStrictEqual({
+    value: -2,
+    unit: "GB",
+  });
+  expect(
+    formatBytes({ value: -1234, unit: "GB" }, { decimals: 3 }),
+  ).toStrictEqual({
+    value: -1.234,
+    unit: "TB",
+  });
+  expect(
+    formatBytes({ value: -1024, unit: "MiB" }, { binary: true }),
+  ).toStrictEqual({
+    value: -1,
+    unit: "GiB",
+  });
+});
+
+it("can convert to a specific unit", () => {
+  expect(
+    formatBytes({ value: 1000000, unit: "B" }, { convertTo: "B" }),
+  ).toStrictEqual({
+    value: 1000000,
+    unit: "B",
+  });
+  expect(
+    formatBytes({ value: 1000000, unit: "B" }, { convertTo: "KB" }),
+  ).toStrictEqual({
+    value: 1000,
+    unit: "KB",
+  });
+  expect(
+    formatBytes({ value: 1000000, unit: "B" }, { convertTo: "MB" }),
+  ).toStrictEqual({
+    value: 1,
+    unit: "MB",
+  });
+  expect(
+    formatBytes(
+      { value: 1000000, unit: "B" },
+      { convertTo: "GB", decimals: 3 },
+    ),
+  ).toStrictEqual({
+    value: 0.001,
+    unit: "GB",
+  });
+  expect(
+    formatBytes(
+      { value: 1000000, unit: "B" },
+      { convertTo: "TB", decimals: 6 },
+    ),
+  ).toStrictEqual({
+    value: 0.000001,
+    unit: "TB",
+  });
+});

--- a/src/lib/utils/formatBytes/formatBytes.ts
+++ b/src/lib/utils/formatBytes/formatBytes.ts
@@ -1,0 +1,61 @@
+type Byte = { value: number; unit: string };
+
+interface FormatBytesConfig {
+  binary?: boolean;
+  convertTo?: string;
+  decimals?: number;
+  roundFunc?: "ceil" | "floor" | "round";
+}
+
+/**
+ * Format bytes to the appropriate/supplied unit at supplied precision.
+ *
+ * @param value - the value in the supplied byte unit
+ * @param unit - the byte unit, e.g. "KB", "TB"
+ * @param binary - whether formatting should be done in base 10 or 2
+ * @param convertTo - the unit to convert to
+ * @param decimals - the decimal places to show, if not a whole number
+ * @param roundFunc - whether to round the value up or down
+ * @returns formatted value and byte unit object
+ */
+export const formatBytes = (
+  { value, unit }: Byte,
+  {
+    binary = false,
+    convertTo,
+    decimals = 2,
+    roundFunc = "round",
+  }: FormatBytesConfig = {},
+): Byte => {
+  const negative = value < 0;
+  const parsedValue = Math.abs(value);
+  if (parsedValue === 0) {
+    return { value: 0, unit: convertTo || "B" };
+  }
+  const k = binary ? 1024 : 1000;
+  const sizes = binary
+    ? ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+    : ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+  // Convert to bytes.
+  const i = sizes.findIndex((size) => size === unit) || 0;
+  const valueInBytes = parsedValue * Math.pow(k, i);
+
+  // Convert to appropriate unit.
+  const j = convertTo
+    ? sizes.findIndex((size) => size === convertTo)
+    : Math.floor(Math.log(valueInBytes) / Math.log(k));
+  let valueInUnit = valueInBytes / Math.pow(k, j);
+
+  // Truncate value to supplied decimal place if not a whole number.
+  const hasDecimal = valueInUnit % 1 !== 0;
+  if (hasDecimal) {
+    const order = Math.pow(10, decimals);
+    valueInUnit = Math[roundFunc](valueInUnit * order) / order;
+  }
+
+  return {
+    value: negative ? -valueInUnit : valueInUnit,
+    unit: sizes[j],
+  };
+};

--- a/src/lib/utils/formatBytes/index.ts
+++ b/src/lib/utils/formatBytes/index.ts
@@ -1,0 +1,1 @@
+export * from "./formatBytes";

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./formatBytes";

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,0 +1,33 @@
+import { CodeSnippet } from "@canonical/react-components";
+
+/**
+ * Returns a component that renders the result of a util function.
+ */
+export const getUtilStoryComponent = <T, U extends (...args: T[]) => T>(
+  fn: U,
+) => {
+  const UtilStoryComponent = (args: T) => {
+    const result = fn(args);
+    return (
+      <>
+        <h1 className="sbdocs-title p-heading--3">{fn.name}</h1>
+        <CodeSnippet
+          blocks={[
+            {
+              title: `${fn.name}(${
+                args != null && typeof args === "object"
+                  ? `{ ${Object.entries(args)
+                      .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+                      .join(", ")} }`
+                  : JSON.stringify(args)
+              })`,
+              code: JSON.stringify(result),
+            },
+          ]}
+        />
+      </>
+    );
+  };
+  UtilStoryComponent.displayName = "UtilStoryComponent";
+  return UtilStoryComponent;
+};


### PR DESCRIPTION
## Done
- feat: add `formatBytes` util
- add utils section to storybook along with utility for easy display of future utils in the docs
- add `storybook-addon-pseudo-states`

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ]  Ensure the component is displayed correctly across all breakpoints

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Fixes
https://warthogs.atlassian.net/browse/MAASENG-2651

## Screenshots
### formatBytes util story
![Google Chrome screenshot 001456@2x](https://github.com/canonical/maas-react-components/assets/7452681/a8d795cf-d021-47ec-8934-651c61bbb7de)

### pseudo states
![Google Chrome screenshot 001454@2x](https://github.com/canonical/maas-react-components/assets/7452681/711a3577-e979-4c8a-82d4-3262b401a8e9)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
