### PR TITLE
feat(multiselect): display previously selected at the top

### DIFF
--- a/src/lib/components/MultiSelect/MultiSelect.scss
+++ b/src/lib/components/MultiSelect/MultiSelect.scss
@@ -3,7 +3,7 @@
 @include vf-base;
 @include vf-p-lists;
 
-  $dropdown-max-height: 20rem;
+$dropdown-max-height: 20rem;
 
 .multi-select {
   position: relative;
@@ -46,6 +46,8 @@
   position: absolute;
   right: 0;
   top: calc(100% - #{$input-margin-bottom});
+  max-height: $dropdown-max-height;
+  overflow: auto;
 }
 
 .multi-select__dropdown--side-by-side {
@@ -61,13 +63,14 @@
   @extend %vf-list;
 
   margin-bottom: $sph--x-small;
-  max-height: $dropdown-max-height;
-  overflow: auto;
 }
 
 .multi-select__footer {
+  background: white;
   display: flex;
   flex-wrap: wrap;
+  position: sticky;
+  bottom: 0;
   justify-content: space-between;
   border-top: 1px solid $color-mid-light;
   padding: $sph--small $sph--large 0 $sph--large;

--- a/src/lib/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/lib/components/MultiSelect/MultiSelect.stories.tsx
@@ -33,12 +33,18 @@ export default meta;
 
 export const CondensedExample = {
   args: {
-    items: Array.from({ length: 10 }, (_, i) => ({
-      label: `Item ${i + 1}`,
-      value: i + 1,
-    })),
+    items: [
+      ...Array.from({ length: 26 }, (_, i) => ({
+        label: `${String.fromCharCode(i + 65)}`,
+        value: `${String.fromCharCode(i + 65)}`,
+      })),
+      ...Array.from({ length: 26 }, (_, i) => ({
+        label: `Item ${i + 1}`,
+        value: i + 1,
+      })),
+    ],
     selectedItems: [
-      { label: "Item 1", value: 1 },
+      { label: "A", value: "A" },
       { label: "Item 2", value: 2 },
     ],
     variant: "condensed",

--- a/src/lib/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/lib/components/MultiSelect/MultiSelect.test.tsx
@@ -168,13 +168,18 @@ it("sorts grouped options alphabetically", async () => {
   render(<MultiSelect items={itemsUnsorted} />);
   await userEvent.click(screen.getByRole("combobox"));
 
-  const checkGroupOrder = (groupName: string, expectedLabels: string[]) => {
+  const checkGroupOrder = async (
+    groupName: string,
+    expectedLabels: string[],
+  ) => {
     const group = screen.getByRole("list", { name: groupName });
-    within(group)
-      .getAllByRole("listitem")
-      .forEach((item, index) => {
-        expect(item).toHaveTextContent(expectedLabels[index]);
-      });
+    await waitFor(() =>
+      within(group)
+        .getAllByRole("listitem")
+        .forEach((item, index) =>
+          expect(item).toHaveTextContent(expectedLabels[index]),
+        ),
+    );
   };
 
   checkGroupOrder("Group 1", ["item A", "item B"]);
@@ -199,4 +204,32 @@ it("hides group title when no items match the search query", async () => {
     screen.queryByRole("heading", { name: "Group 1" }),
   ).not.toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "Group 2" })).toBeInTheDocument();
+});
+
+it("displays previously selected items at the top of the list in a sorted order", async () => {
+  const items = [
+    { label: "item two", value: 2 },
+    { label: "item one", value: 1 },
+  ];
+  const unSortedSelectedItems = [items[1], items[0]];
+
+  render(<MultiSelect items={items} selectedItems={unSortedSelectedItems} />);
+
+  await userEvent.click(screen.getByRole("combobox"));
+
+  const listItems = screen.getAllByRole("listitem");
+
+  await waitFor(() => {
+    expect(listItems[0]).toHaveTextContent("item one");
+    expect(listItems[1]).toHaveTextContent("item two");
+  });
+});
+
+it("opens and closes the dropdown on click", async () => {
+  render(<MultiSelect variant="condensed" items={items} />);
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  await userEvent.click(screen.getByRole("combobox"));
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("combobox"));
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Done
- feat(multiselect): display previously selected items at the top
- fix: use correct max height when multiple groups are used
- docs: update examples to include alphanumeric labels

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Ensure the component is displayed correctly across all breakpoints
- [ ] Test both condensed and search examples in storybook:
  - [ ] Select additional items
  - [ ] Close the dropdown
  - [ ] Reopen the dropdown
  - [ ] Ensure items have been placed at the top of their group and all items are sorted alphabetically

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-2625

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
