### PR TITLE
fix(style): remove absolute icon positioning to prevent overlapping

### DIFF
--- a/src/lib/sections/MainToolbar/MainToolbar.scss
+++ b/src/lib/sections/MainToolbar/MainToolbar.scss
@@ -47,12 +47,7 @@
     // overrides to fix the search box wrapping to the next line
     .p-search-box {
       .p-search-box__input {
-        position: static;
         padding-right: initial;
-      }
-
-      .p-search-box__button {
-        position: absolute;
       }
     }
 


### PR DESCRIPTION
## Done
- Removed absolute positioning for search icon to prevent overlap

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ]  Ensure the component is displayed correctly across all breakpoints
- [ ] Connect this version to MSM (see README.md for details) 
- [ ] Ensure that the site list search input displays correctly across different breakpoints

## Fixes

Fixes: [MAASENG-2898](https://warthogs.atlassian.net/browse/MAASENG-2898)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-react-components/assets/47540149/f7587af2-70fe-4bd1-aa80-28a704a819a0)

### Updated
![image](https://github.com/canonical/maas-react-components/assets/47540149/7d2211d7-0e58-4fd9-a0c5-c41cfabf403e)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2898]: https://warthogs.atlassian.net/browse/MAASENG-2898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ