### PR TITLE
feat: allow multiple DynamicTable per page MAASENG-3091

### DIFF
--- a/src/lib/components/DynamicTable/DynamicTable.scss
+++ b/src/lib/components/DynamicTable/DynamicTable.scss
@@ -20,7 +20,16 @@
   }
 
   thead {
-    scrollbar-gutter: stable;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: white;
+  }
+
+  &.is-full-height {
+    thead {
+      scrollbar-gutter: stable;
+    }
   }
 
   thead tr,

--- a/src/lib/components/DynamicTable/DynamicTable.stories.tsx
+++ b/src/lib/components/DynamicTable/DynamicTable.stories.tsx
@@ -21,6 +21,7 @@ export default meta;
 export const Example: StoryObj<typeof DynamicTable> = {
   args: {
     className: "machines-table",
+    variant: "full-height",
     children: (
       <>
         <thead>
@@ -50,6 +51,74 @@ export const Example: StoryObj<typeof DynamicTable> = {
             </tr>
           ))}
         </DynamicTable.Body>
+      </>
+    ),
+  },
+};
+
+export const TwoTablesExample: StoryObj<typeof DynamicTable> = {
+  render: (args) => <div>{args.children}</div>,
+  args: {
+    children: (
+      <>
+        <DynamicTable className="first-table" variant="regular">
+          <thead>
+            <tr>
+              <th>FQDN</th>
+              <th>IP address</th>
+              <th>Zone</th>
+              <th>Owner</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <DynamicTable.Body>
+            {data.slice(0, 10).map((item) => (
+              <tr key={item.fqdn}>
+                <td>{item.fqdn}</td>
+                <td>{item.ipAddress}</td>
+                <td>{item.zone}</td>
+                <td>{item.owner}</td>
+                <td>
+                  <Button
+                    appearance="base"
+                    style={{ marginBottom: 0, padding: 0 }}
+                  >
+                    <Icon name="delete" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </DynamicTable.Body>
+        </DynamicTable>
+        <DynamicTable className="second-table" variant="regular">
+          <thead>
+            <tr>
+              <th>FQDN</th>
+              <th>IP address</th>
+              <th>Zone</th>
+              <th>Owner</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <DynamicTable.Body>
+            {data.slice(10, 20).map((item) => (
+              <tr key={item.fqdn}>
+                <td>{item.fqdn}</td>
+                <td>{item.ipAddress}</td>
+                <td>{item.zone}</td>
+                <td>{item.owner}</td>
+                <td>
+                  <Button
+                    appearance="base"
+                    style={{ marginBottom: 0, padding: 0 }}
+                  >
+                    <Icon name="delete" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </DynamicTable.Body>
+        </DynamicTable>
       </>
     ),
   },

--- a/src/lib/components/DynamicTable/DynamicTable.test.tsx
+++ b/src/lib/components/DynamicTable/DynamicTable.test.tsx
@@ -23,7 +23,7 @@ beforeAll(() => {
   } as DOMRect);
 });
 
-it("sets a fixed table body height based on top offset on large screens", async () => {
+it("sets a fixed table body height based on top offset on large screens in full-height variant", async () => {
   vi.spyOn(window, "innerWidth", "get").mockReturnValue(BREAKPOINTS.xSmall);
 
   await act(async () => {
@@ -31,7 +31,7 @@ it("sets a fixed table body height based on top offset on large screens", async 
   });
 
   const { container } = render(
-    <DynamicTable>
+    <DynamicTable variant="full-height">
       <DynamicTable.Body className="test-class">
         <tr>
           <td>Test content</td>
@@ -48,6 +48,7 @@ it("sets a fixed table body height based on top offset on large screens", async 
 
   // does not alter the height on small screens
   expect(tbody).toHaveStyle("height: undefined");
+  expect(container.querySelector("table")).toHaveClass("is-full-height");
 
   vi.spyOn(window, "innerWidth", "get").mockReturnValue(BREAKPOINTS.large);
 
@@ -60,9 +61,27 @@ it("sets a fixed table body height based on top offset on large screens", async 
   );
 });
 
+it("does not apply dynamic height in regular variant", async () => {
+  vi.spyOn(window, "innerWidth", "get").mockReturnValue(BREAKPOINTS.large);
+  const { container } = render(
+    <DynamicTable variant="regular">
+      <DynamicTable.Body>
+        <tr>
+          <td>Test content</td>
+        </tr>
+      </DynamicTable.Body>
+    </DynamicTable>,
+  );
+  await act(async () => {
+    fireEvent(window, new Event("resize"));
+  });
+  const tbody = container.querySelector("tbody");
+  await vi.waitFor(() => expect(tbody).toHaveStyle("height: undefined"));
+});
+
 it("displays loading state", () => {
   const { container } = render(
-    <DynamicTable>
+    <DynamicTable variant="regular">
       <DynamicTable.Loading />
     </DynamicTable>,
   );

--- a/src/lib/components/TableCaption/TableCaption.stories.tsx
+++ b/src/lib/components/TableCaption/TableCaption.stories.tsx
@@ -24,7 +24,7 @@ export const Example: StoryObj<typeof TableCaption> = {
     ),
   },
   render: (args) => (
-    <DynamicTable>
+    <DynamicTable variant="regular">
       <thead>
         <tr>
           <th>FQDN</th>


### PR DESCRIPTION
## Done
- feat: allow multiple DynamicTable per page MAASENG-3091
- add `variant` prop
- use React's Context API for managing the variant prop.

_Note: Variant prop is required deliberately so that we're careful when updating existing implementations and carefully chose which variant should be used._

#### Why Context API?
Context API provides a way to pass data through the component tree without having to pass props down manually at every level. This also allows to use this prop in all child components and make sure it's consistent and cannot be overwritten.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ]  Ensure the component is displayed correctly across all breakpoints
- [ ] Verify it works correctly in supported browsers (at least Firefox and Chrome)
- [ ] Make sure headers and body cells are aligned in both variants.

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-3091 https://github.com/canonical/maas-react-components/issues/128

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
### After
![Google Chrome screenshot 001853@2x](https://github.com/canonical/maas-react-components/assets/7452681/6d4fc8d1-5488-498c-96c9-183f86b17ccf)




## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
