### PR TITLE
feat: Upstream GenericTable MAASENG-4794

### DIFF
--- a/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.scss
+++ b/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.scss
@@ -3,6 +3,7 @@
 
 .p-button--table-header {
   @extend %table-header-label;
+
   color: $color-dark;
   margin: 0;
   padding: 0;
@@ -13,6 +14,7 @@
 
   [class*="p-icon"] {
     @include vf-icon-size(0.875rem);
+
     margin-left: $sp-x-small;
   }
 }

--- a/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.scss
+++ b/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.scss
@@ -1,0 +1,22 @@
+@import "vanilla-framework";
+@include vanilla;
+
+.p-button--table-header {
+  @extend %table-header-label;
+  color: $color-dark;
+  margin: 0;
+  padding: 0;
+
+  &:hover {
+    color: $color-link;
+  }
+
+  [class*="p-icon"] {
+    @include vf-icon-size(0.875rem);
+    margin-left: $sp-x-small;
+  }
+}
+
+[class*="p-button"].no-background {
+  background-color: transparent;
+}

--- a/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.tsx
+++ b/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement } from "react";
+
+import { Button } from "@canonical/react-components";
+import type { Header } from "@tanstack/react-table";
+import { flexRender } from "@tanstack/react-table";
+import classNames from "classnames";
+
+import SortingIndicator from "@/lib/components/GenericTable/SortingIndicator";
+
+type TableHeaderProps<T> = {
+  header: Header<T, unknown>;
+};
+
+const ColumnHeader = <T,>({ header }: TableHeaderProps<T>): ReactElement => {
+  return (
+    <th className={classNames(`${header.column.id}`)} key={header.id}>
+      {header.column.getCanSort() ? (
+        <Button
+          appearance="link"
+          className="p-button--table-header"
+          onClick={header.column.getToggleSortingHandler()}
+          type="button"
+        >
+          <>
+            {flexRender(header.column.columnDef.header, header.getContext())}
+            <SortingIndicator header={header} />
+          </>
+        </Button>
+      ) : (
+        flexRender(header.column.columnDef.header, header.getContext())
+      )}
+    </th>
+  );
+};
+
+export default ColumnHeader;

--- a/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.tsx
+++ b/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.tsx
@@ -7,6 +7,8 @@ import classNames from "classnames";
 
 import SortingIndicator from "@/lib/components/GenericTable/SortingIndicator";
 
+import "./ColumnHeader.scss";
+
 type TableHeaderProps<T> = {
   header: Header<T, unknown>;
 };
@@ -17,7 +19,7 @@ const ColumnHeader = <T,>({ header }: TableHeaderProps<T>): ReactElement => {
       {header.column.getCanSort() ? (
         <Button
           appearance="link"
-          className="p-button--table-header"
+          className="table-header-label p-button--table-header"
           onClick={header.column.getToggleSortingHandler()}
           type="button"
         >

--- a/src/lib/components/GenericTable/ColumnHeader/index.ts
+++ b/src/lib/components/GenericTable/ColumnHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ColumnHeader";

--- a/src/lib/components/GenericTable/GenericTable.scss
+++ b/src/lib/components/GenericTable/GenericTable.scss
@@ -21,16 +21,16 @@
     }
 
     &__right {
+      display: flex;
       width: 100%;
       margin-left: auto;
       margin-right: 0;
 
       .p-pagination {
         z-index: 2;
-        padding-right: 2rem;
       }
 
-      @media screen and (min-width: 620px) {
+      @media screen and (width >= 620px) {
         width: auto;
       }
     }
@@ -97,6 +97,7 @@
       tr:hover,
       tr:focus-within {
         @include vf-transition($property: background, $duration: fast);
+
         background-color: $colors--light-theme--background-hover;
       }
     }
@@ -109,7 +110,7 @@
     }
 
     // Hide selection columns when not selectable
-    th.p-generic-table__select,
+    &:is(.p-generic-table__is-selectable.p-generic-table__is-grouped) > * th.p-generic-table__select,
     &:not(.p-generic-table__is-selectable) > * .p-generic-table__select-alignment {
       display: none;
     }

--- a/src/lib/components/GenericTable/GenericTable.scss
+++ b/src/lib/components/GenericTable/GenericTable.scss
@@ -1,0 +1,123 @@
+@import "vanilla-framework";
+
+// Generic Table main component
+.p-generic-table {
+  // Pagination and controls section
+  .controls-bar {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0;
+    margin-top: 1rem;
+    border-top: 1px solid #d9d9d9;
+    border-bottom: 1px solid #d9d9d9;
+
+    .p-form--inline {
+      width: 100%;
+    }
+
+    &__left {
+      margin: 0;
+      padding: 0;
+    }
+
+    &__right {
+      width: 100%;
+      margin-left: auto;
+      margin-right: 0;
+
+      .p-pagination {
+        z-index: 2;
+        padding-right: 2rem;
+      }
+
+      @media screen and (min-width: 620px) {
+        width: auto;
+      }
+    }
+  }
+
+  // Table structure and layout
+  .p-generic-table__table {
+    margin-bottom: 0;
+
+    // Common styles for thead and tbody
+    thead,
+    tbody {
+      display: block;
+      overflow: auto;
+      width: 100%;
+    }
+
+    // Header styling
+    thead {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background-color: white;
+
+      th {
+        button {
+          padding-top: 0;
+          margin-bottom: 0;
+        }
+
+        &:last-child {
+          text-align: right;
+        }
+      }
+    }
+
+    // Full-height variant
+    &.p-generic-table__is-full-height {
+      thead {
+        scrollbar-gutter: stable;
+      }
+    }
+
+    // Row layout
+    thead tr,
+    tbody tr {
+      display: table;
+      table-layout: fixed;
+      width: 100%;
+    }
+
+    // Body styling
+    tbody {
+      height: auto;
+      min-height: auto;
+
+      td:last-child {
+        text-align: right;
+      }
+    }
+
+    // Row hover effects
+    &:not([aria-busy="true"]) tbody:not([aria-busy="true"]) {
+      tr:hover,
+      tr:focus-within {
+        @include vf-transition($property: background, $duration: fast);
+        background-color: $colors--light-theme--background-hover;
+      }
+    }
+
+    // Selection column styling
+    .p-generic-table__group-select,
+    .p-generic-table__select,
+    .p-generic-table__select-alignment {
+      width: 2rem;
+    }
+
+    // Hide selection columns when not selectable
+    th.p-generic-table__select,
+    &:not(.p-generic-table__is-selectable) > * .p-generic-table__select-alignment {
+      display: none;
+    }
+
+    // Empty and loading states
+    td.p-generic-table__no-data, td.p-generic-table__loading {
+      padding: 2rem;
+      text-align: center !important;
+    }
+  }
+}

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -4,7 +4,6 @@ import { Button, Icon } from "@canonical/react-components";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   Column,
-  ColumnDef,
   Getter,
   Header,
   Row,
@@ -15,17 +14,8 @@ import GenericTable from "./GenericTable";
 
 import GroupRowActions from "@/lib/components/GenericTable/GroupRowActions";
 
-type MachineData = {
-  id: number;
-  fqdn: string;
-  ipAddress: string;
-  status: string;
-  zone: string;
-  pool: string;
-};
-
 // Sample data for MAAS machines
-const generateMachinesData = (count: number): MachineData[] => {
+const generateMachinesData = (count: number) => {
   const statuses = ["Ready", "Deployed", "Commissioning"];
   const zones = ["default", "zone-1", "zone-2", "zone-3"];
   const pools = ["default", "pool-1", "pool-2"];
@@ -41,7 +31,7 @@ const generateMachinesData = (count: number): MachineData[] => {
 };
 
 // Column definitions for the MAAS machines table
-const machineColumns: ColumnDef<MachineData, Partial<MachineData>>[] = [
+const machineColumns = [
   {
     id: "fqdn",
     accessorKey: "fqdn",
@@ -56,7 +46,7 @@ const machineColumns: ColumnDef<MachineData, Partial<MachineData>>[] = [
     id: "status",
     accessorKey: "status",
     header: "Status",
-    cell: ({ getValue }: { getValue: Getter<MachineData["status"]> }) => (
+    cell: ({ getValue }: { getValue: Getter<string> }) => (
       <span className={`status-${getValue().toLowerCase()}`}>{getValue()}</span>
     ),
   },
@@ -72,8 +62,9 @@ const machineColumns: ColumnDef<MachineData, Partial<MachineData>>[] = [
   },
   {
     id: "actions",
+    accessorKey: "id",
     header: "Actions",
-    cell: ({ row }) => {
+    cell: ({ row }: { row: Row<{ id: string | number }> }) => {
       if (row.getIsGrouped()) return <GroupRowActions row={row} />;
       return (
         <div className="actions-cell">
@@ -91,7 +82,7 @@ const machineColumns: ColumnDef<MachineData, Partial<MachineData>>[] = [
 
 const mockMachineData = generateMachinesData(10);
 
-const meta: Meta<typeof GenericTable<MachineData>> = {
+const meta: Meta<typeof GenericTable> = {
   title: "Components/GenericTable",
   component: GenericTable,
   parameters: {
@@ -193,8 +184,8 @@ export const Grouped: Story = {
           row,
           getValue,
         }: {
-          row: Row<MachineData>;
-          getValue: Getter<MachineData["status"]>;
+          row: Row<{ id: string | number }>;
+          getValue: Getter<string>;
         }) => {
           return (
             <div>
@@ -212,8 +203,8 @@ export const Grouped: Story = {
     ],
     groupBy: ["status"],
     filterCells: (
-      row: Row<MachineData>,
-      column: Column<MachineData>,
+      row: Row<{ id: string | number }>,
+      column: Column<{ id: string | number }>,
     ): boolean => {
       if (row.getIsGrouped()) {
         return ["status", "actions"].includes(column.id);
@@ -221,8 +212,9 @@ export const Grouped: Story = {
         return !["status"].includes(column.id);
       }
     },
-    filterHeaders: (header: Header<MachineData, unknown>): boolean =>
-      header.column.id !== "status",
+    filterHeaders: (
+      header: Header<{ id: string | number }, unknown>,
+    ): boolean => header.column.id !== "status",
   },
 };
 
@@ -276,8 +268,8 @@ export const GroupedSelectable: Story = {
           row,
           getValue,
         }: {
-          row: Row<MachineData>;
-          getValue: Getter<MachineData["status"]>;
+          row: Row<{ id: string | number }>;
+          getValue: Getter<string>;
         }) => {
           return (
             <div>
@@ -295,8 +287,8 @@ export const GroupedSelectable: Story = {
     ],
     groupBy: ["status"],
     filterCells: (
-      row: Row<MachineData>,
-      column: Column<MachineData>,
+      row: Row<{ id: string | number }>,
+      column: Column<{ id: string | number }>,
     ): boolean => {
       if (row.getIsGrouped()) {
         return ["status", "actions"].includes(column.id);
@@ -304,8 +296,9 @@ export const GroupedSelectable: Story = {
         return !["status"].includes(column.id);
       }
     },
-    filterHeaders: (header: Header<MachineData, unknown>): boolean =>
-      header.column.id !== "status",
+    filterHeaders: (
+      header: Header<{ id: string | number }, unknown>,
+    ): boolean => header.column.id !== "status",
   },
 };
 

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -1,0 +1,384 @@
+import { useRef, useState } from "react";
+
+import { Button, Icon } from "@canonical/react-components";
+import { Meta, StoryObj } from "@storybook/react";
+import {
+  Column,
+  ColumnDef,
+  Getter,
+  Header,
+  Row,
+  RowSelectionState,
+} from "@tanstack/react-table";
+
+import GenericTable from "./GenericTable";
+
+import GroupRowActions from "@/lib/components/GenericTable/GroupRowActions";
+
+type MachineData = {
+  id: number;
+  fqdn: string;
+  ipAddress: string;
+  status: string;
+  zone: string;
+  pool: string;
+};
+
+// Sample data for MAAS machines
+const generateMachinesData = (count: number): MachineData[] => {
+  const statuses = ["Ready", "Deployed", "Commissioning"];
+  const zones = ["default", "zone-1", "zone-2", "zone-3"];
+  const pools = ["default", "pool-1", "pool-2"];
+
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    fqdn: `machine-${i + 1}.maas`,
+    ipAddress: `192.168.1.${i + 1}`,
+    status: statuses[i % statuses.length],
+    zone: zones[i % zones.length],
+    pool: pools[i % pools.length],
+  }));
+};
+
+// Column definitions for the MAAS machines table
+const machineColumns: ColumnDef<MachineData, Partial<MachineData>>[] = [
+  {
+    id: "fqdn",
+    accessorKey: "fqdn",
+    header: "FQDN",
+  },
+  {
+    id: "ipAddress",
+    accessorKey: "ipAddress",
+    header: "IP Address",
+  },
+  {
+    id: "status",
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ getValue }: { getValue: Getter<MachineData["status"]> }) => (
+      <span className={`status-${getValue().toLowerCase()}`}>{getValue()}</span>
+    ),
+  },
+  {
+    id: "zone",
+    accessorKey: "zone",
+    header: "Zone",
+  },
+  {
+    id: "pool",
+    accessorKey: "pool",
+    header: "Pool",
+  },
+  {
+    id: "actions",
+    header: "Actions",
+    cell: ({ row }) => {
+      if (row.getIsGrouped()) return <GroupRowActions row={row} />;
+      return (
+        <div className="actions-cell">
+          <Button appearance="base" hasIcon>
+            <Icon name="settings" />
+          </Button>
+          <Button appearance="base" hasIcon>
+            <Icon name="delete" />
+          </Button>
+        </div>
+      );
+    },
+  },
+];
+
+const mockMachineData = generateMachinesData(10);
+
+const meta: Meta<typeof GenericTable> = {
+  title: "Components/GenericTable",
+  component: GenericTable,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    columns: machineColumns,
+    data: mockMachineData.slice(0, 5),
+    isLoading: false,
+    variant: "regular",
+  },
+  argTypes: {
+    variant: {
+      control: { type: "radio" },
+      options: ["full-height", "regular"],
+    },
+    isLoading: {
+      control: { type: "boolean" },
+    },
+    canSelect: {
+      control: { type: "boolean" },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GenericTable>;
+
+// Basic table example
+export const Default: Story = {};
+
+export const Loading: Story = {
+  args: {
+    data: [],
+    isLoading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    data: [],
+    noData: "No machines found",
+  },
+};
+
+export const Selectable: Story = {
+  render: (args) => {
+    const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+    return (
+      <div style={{ width: "100%" }}>
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "space-between",
+            marginBottom: "1rem",
+          }}
+        >
+          <h5>Selected machines: {Object.keys(rowSelection).length}</h5>
+          <div className="p-button-group">
+            <Button
+              appearance="negative"
+              disabled={Object.keys(rowSelection).length === 0}
+            >
+              Delete
+            </Button>
+          </div>
+        </div>
+        <GenericTable
+          {...args}
+          rowSelection={rowSelection}
+          setRowSelection={setRowSelection}
+        />
+      </div>
+    );
+  },
+  args: {
+    canSelect: true,
+  },
+};
+
+export const Grouped: Story = {
+  args: {
+    columns: [
+      {
+        id: "status",
+        accessorKey: "status",
+        cell: ({
+          row,
+          getValue,
+        }: {
+          row: Row<MachineData>;
+          getValue: Getter<MachineData["status"]>;
+        }) => {
+          return (
+            <div>
+              <div>
+                <strong>{getValue()}</strong>
+              </div>
+              <small className="u-text--muted">
+                {`${row.getLeafRows().length} machine${row.getLeafRows().length > 1 ? "s" : ""}`}
+              </small>
+            </div>
+          );
+        },
+      },
+      ...machineColumns.filter((column) => column.id !== "status"),
+    ],
+    groupBy: ["status"],
+    filterCells: (
+      row: Row<MachineData>,
+      column: Column<MachineData>,
+    ): boolean => {
+      if (row.getIsGrouped()) {
+        return ["status", "actions"].includes(column.id);
+      } else {
+        return !["status"].includes(column.id);
+      }
+    },
+    filterHeaders: (header: Header<MachineData, unknown>): boolean =>
+      header.column.id !== "status",
+  },
+};
+
+export const GroupedSelectable: Story = {
+  name: "Grouped (Selectable)",
+  render: (args) => {
+    const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+    return (
+      <div style={{ width: "100%" }}>
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "space-between",
+            marginBottom: "1rem",
+          }}
+        >
+          <h5>
+            Selected machines:{" "}
+            {
+              Object.keys(rowSelection).filter(
+                (key: string) => !isNaN(Number(key)),
+              ).length
+            }
+          </h5>
+          <div className="p-button-group">
+            <Button
+              appearance="negative"
+              disabled={Object.keys(rowSelection).length === 0}
+            >
+              Delete
+            </Button>
+          </div>
+        </div>
+        <GenericTable
+          {...args}
+          rowSelection={rowSelection}
+          setRowSelection={setRowSelection}
+        />
+      </div>
+    );
+  },
+  args: {
+    canSelect: true,
+    columns: [
+      {
+        id: "status",
+        accessorKey: "status",
+        cell: ({
+          row,
+          getValue,
+        }: {
+          row: Row<MachineData>;
+          getValue: Getter<MachineData["status"]>;
+        }) => {
+          return (
+            <div>
+              <div>
+                <strong>{getValue()}</strong>
+              </div>
+              <small className="u-text--muted">
+                {`${row.getLeafRows().length} machine${row.getLeafRows().length > 1 ? "s" : ""}`}
+              </small>
+            </div>
+          );
+        },
+      },
+      ...machineColumns.filter((column) => column.id !== "status"),
+    ],
+    groupBy: ["status"],
+    filterCells: (
+      row: Row<MachineData>,
+      column: Column<MachineData>,
+    ): boolean => {
+      if (row.getIsGrouped()) {
+        return ["status", "actions"].includes(column.id);
+      } else {
+        return !["status"].includes(column.id);
+      }
+    },
+    filterHeaders: (header: Header<MachineData, unknown>): boolean =>
+      header.column.id !== "status",
+  },
+};
+
+export const Paginated: Story = {
+  render: (args) => {
+    const [currentPage, setCurrentPage] = useState(1);
+    const [itemsPerPage, setItemsPerPage] = useState(5);
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const paginatedData = mockMachineData.slice(
+      startIndex,
+      startIndex + itemsPerPage,
+    );
+
+    const handlePageSizeChange = (size: number) => {
+      setItemsPerPage(size);
+      setCurrentPage(1);
+    };
+
+    return (
+      <GenericTable
+        {...args}
+        data={paginatedData}
+        pagination={{
+          currentPage,
+          setCurrentPage,
+          itemsPerPage,
+          totalItems: mockMachineData.length,
+          handlePageSizeChange,
+          dataContext: "machines",
+          isPending: false,
+          pageSizes: [5, 10, 20],
+        }}
+      />
+    );
+  },
+};
+
+export const Searchable: Story = {
+  render: (args) => {
+    const [search, setSearch] = useState("");
+
+    const filteredData = mockMachineData.filter(
+      (item) =>
+        item.fqdn.toLowerCase().includes(search.toLowerCase()) ||
+        item.zone.toLowerCase().includes(search.toLowerCase()) ||
+        item.pool.toLowerCase().includes(search.toLowerCase()),
+    );
+
+    return (
+      <div style={{ width: "100%" }}>
+        <div style={{ marginBottom: "1rem" }}>
+          <input
+            type="text"
+            placeholder="Search machines..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{ padding: "0.5rem", width: "100%" }}
+          />
+        </div>
+        <GenericTable
+          {...args}
+          data={filteredData}
+          noData="No matching machines found"
+        />
+      </div>
+    );
+  },
+};
+
+export const Scrollable: Story = {
+  render: (args) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    return (
+      <div style={{ width: "100%", height: "480px" }} ref={containerRef}>
+        <GenericTable {...args} containerRef={containerRef} />
+      </div>
+    );
+  },
+  args: {
+    data: generateMachinesData(50),
+    variant: "full-height",
+  },
+};

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -104,15 +104,155 @@ const meta: Meta<typeof GenericTable> = {
     variant: "regular",
   },
   argTypes: {
-    variant: {
-      control: { type: "radio" },
-      options: ["full-height", "regular"],
+    // Main configuration
+    columns: {
+      description: "Column definitions that specify how to display and interact with table data",
+      control: false,
+      table: {
+        type: { summary: "ColumnDef<T, Partial<T>>[]" },
+        category: "Required",
+      },
+    },
+    data: {
+      description: "Array of data objects to be displayed in the table",
+      control: false,
+      table: {
+        type: { summary: "T[]" },
+        category: "Required",
+      },
     },
     isLoading: {
+      description: "Controls the loading state of the table. When true, displays placeholder content",
       control: { type: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "State",
+      },
     },
+    variant: {
+      description: "Determines the table layout style. 'full-height' takes up all available vertical space, 'regular' uses content-based height",
+      control: { type: "radio" },
+      options: ["full-height", "regular"],
+      table: {
+        type: { summary: "string" },
+        defaultValue: { summary: "full-height" },
+        category: "Appearance",
+      },
+    },
+
+    // Selection related
     canSelect: {
+      description: "Enables row selection with checkboxes in the first column. When true, rowSelection and setRowSelection props must be provided",
       control: { type: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Selection",
+      },
+    },
+    rowSelection: {
+      description: "State object that tracks which rows are currently selected. Required when canSelect is true",
+      control: false,
+      table: {
+        type: { summary: "RowSelectionState" },
+        category: "Selection",
+        required: { condition: { name: "canSelect", value: true } },
+      },
+    },
+    setRowSelection: {
+      description: "State setter function for updating row selection. Required when canSelect is true",
+      control: false,
+      table: {
+        type: { summary: "Dispatch<SetStateAction<RowSelectionState>>" },
+        category: "Selection",
+        required: { condition: { name: "canSelect", value: true } },
+      },
+    },
+
+    // Grouping related
+    groupBy: {
+      description: "Array of column IDs to group rows by",
+      control: false,
+      table: {
+        type: { summary: "string[]" },
+        category: "Grouping",
+      },
+    },
+    pinGroup: {
+      description: "Configuration for pinning groups to top or bottom of the table",
+      control: false,
+      table: {
+        type: { summary: "{ value: string; isTop: boolean }[]" },
+        category: "Grouping",
+      },
+    },
+
+    // Sorting
+    sortBy: {
+      description: "Initial sort configuration for table columns",
+      control: false,
+      table: {
+        type: { summary: "ColumnSort[]" },
+        category: "Sorting",
+      },
+    },
+
+    // Filtering
+    filterCells: {
+      description: "Function to determine which cells should be displayed",
+      control: false,
+      table: {
+        type: { summary: "Function" },
+        category: "Filtering",
+      },
+    },
+    filterHeaders: {
+      description: "Function to determine which headers should be displayed",
+      control: false,
+      table: {
+        type: { summary: "Function" },
+        category: "Filtering",
+      },
+    },
+
+    // Pagination
+    pagination: {
+      description: "Configuration for table pagination including current page, page size, and navigation handlers",
+      control: false,
+      table: {
+        type: { summary: "PaginationBarProps" },
+        category: "Pagination",
+      },
+    },
+
+    // Styling and references
+    className: {
+      description: "Additional CSS class for the table wrapper",
+      control: { type: "text" },
+      table: {
+        type: { summary: "string" },
+        category: "Styling",
+      },
+    },
+    containerRef: {
+      description: "Reference to container element for size calculations",
+      control: false,
+      table: {
+        type: { summary: "RefObject<HTMLElement | null>" },
+        defaultValue: { summary: "<main>" },
+        category: "References",
+      },
+    },
+
+    // Empty state
+    noData: {
+      description: "Custom content to display when the table has no data",
+      control: false,
+      table: {
+        type: { summary: "ReactNode" },
+        category: "Empty State",
+      },
     },
   },
 };

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -91,11 +91,19 @@ const machineColumns: ColumnDef<MachineData, Partial<MachineData>>[] = [
 
 const mockMachineData = generateMachinesData(10);
 
-const meta: Meta<typeof GenericTable> = {
+const meta: Meta<typeof GenericTable<MachineData>> = {
   title: "Components/GenericTable",
   component: GenericTable,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component:
+          "GenericTable is a flexible table component built with TanStack Table that supports " +
+          "selection, grouping, pagination, and more. It's designed to handle various data " +
+          "display needs while maintaining a consistent design language.",
+      },
+    },
   },
   tags: ["autodocs"],
   args: {
@@ -122,7 +130,6 @@ export default meta;
 
 type Story = StoryObj<typeof GenericTable>;
 
-// Basic table example
 export const Default: Story = {};
 
 export const Loading: Story = {

--- a/src/lib/components/GenericTable/GenericTable.test.tsx
+++ b/src/lib/components/GenericTable/GenericTable.test.tsx
@@ -1,0 +1,466 @@
+import { useRef } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import GenericTable from "./GenericTable";
+
+import type { PaginationBarProps } from "@/lib/components/GenericTable/PaginationBar";
+
+export type Image = {
+  id: number;
+  release: string;
+  architecture: string;
+  name: string;
+  size: string;
+  lastSynced: string | null;
+  canDeployToMemory: boolean;
+  status: string;
+  lastDeployed: string;
+  machines: number;
+};
+
+describe("GenericTable", () => {
+  // Set up ResizeObserver mock before each test
+  beforeEach(() => {
+    // Mock the ResizeObserver
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+
+    // Mock window event listeners
+    window.addEventListener = vi.fn();
+    window.removeEventListener = vi.fn();
+  });
+
+  const columns: ColumnDef<Image, Partial<Image>>[] = [
+    {
+      id: "release",
+      accessorKey: "release",
+      enableSorting: true,
+      header: () => "Release title",
+    },
+    {
+      id: "architecture",
+      accessorKey: "architecture",
+      enableSorting: false,
+      header: () => "Architecture",
+    },
+    {
+      id: "size",
+      accessorKey: "size",
+      enableSorting: false,
+      header: () => "Size",
+    },
+  ];
+
+  const data: Image[] = [
+    {
+      id: 0,
+      release: "16.04 LTS",
+      architecture: "amd64",
+      name: "Ubuntu",
+      size: "1.3 MB",
+      lastSynced: "Mon, 06 Jan. 2025 10:45:24",
+      canDeployToMemory: true,
+      status: "Synced",
+      lastDeployed: "Thu, 15 Aug. 2019 06:21:39",
+      machines: 2,
+    },
+    {
+      id: 1,
+      release: "18.04 LTS",
+      architecture: "arm64",
+      name: "Ubuntu",
+      size: "1.3 MB",
+      lastSynced: "Mon, 06 Jan. 2025 10:45:24",
+      canDeployToMemory: true,
+      status: "Synced",
+      lastDeployed: "Thu, 15 Aug. 2019 06:21:39",
+      machines: 2,
+    },
+  ];
+
+  const mockFilterCells = vi.fn(() => true);
+  const mockFilterHeaders = vi.fn(() => true);
+
+  it("renders table with headers and rows", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Release title")).toBeInTheDocument();
+    expect(screen.getByText("Architecture")).toBeInTheDocument();
+
+    expect(screen.getByText("16.04 LTS")).toBeInTheDocument();
+    expect(screen.getByText("18.04 LTS")).toBeInTheDocument();
+  });
+
+  it("can change pages", async () => {
+    const setPagination = vi.fn();
+    const pagination: PaginationBarProps = {
+      currentPage: 1,
+      dataContext: "",
+      handlePageSizeChange: vi.fn(),
+      isPending: false,
+      itemsPerPage: 10,
+      setCurrentPage: setPagination,
+      totalItems: 100,
+    };
+    render(
+      <GenericTable
+        columns={columns}
+        data={[]}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        noData={<span>No data</span>}
+        pagination={pagination}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Next page" })
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(setPagination).toHaveBeenCalled();
+  });
+
+  it('displays "No data" when the data array is empty', () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={[]}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        noData={<span>No data</span>}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+
+  it("applies sorting when a sortable header is clicked", async () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByText("Release title"));
+
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("16.04 LTS");
+    expect(rows[2]).toHaveTextContent("18.04 LTS");
+  });
+
+  // New tests to cover more features
+
+  it("renders loading state correctly", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={true}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Table should have aria-busy attribute when loading
+    const table = screen.getByRole("grid");
+    expect(table).toHaveAttribute("aria-busy", "true");
+
+    // Should render placeholders
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("supports row selection when canSelect is true", async () => {
+    const mockSetRowSelection = vi.fn();
+    render(
+      <GenericTable
+        canSelect={true}
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={mockSetRowSelection}
+      />
+    );
+
+    // Should render checkboxes
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+
+    // Click on a checkbox should trigger selection change
+    await userEvent.click(checkboxes[1]); // Click first row checkbox
+    expect(mockSetRowSelection).toHaveBeenCalled();
+  });
+
+  it("uses custom class names when provided", () => {
+    render(
+      <GenericTable
+        className="custom-table-class"
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    const tableWrapper =
+      screen.getByTestId("p-generic-table") ||
+      screen.getByRole("grid").closest(".p-generic-table");
+    expect(tableWrapper).toHaveClass("custom-table-class");
+  });
+
+  it("supports grouping rows by specified columns", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        groupBy={["release"]}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Check if grouped rows are rendered correctly
+    const groupRows = screen
+      .getAllByRole("row")
+      .filter((row) => row.classList.contains("p-generic-table__group-row"));
+    expect(groupRows.length).toBeGreaterThan(0);
+  });
+
+  it("supports expanded/collapsed state for grouped rows", async () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        groupBy={["release"]}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Find expand/collapse buttons and click one
+    const expandButtons = screen
+      .getAllByRole("button")
+      .filter(
+        (button) =>
+          button.getAttribute("aria-label")?.includes("expand") ||
+          button.getAttribute("aria-label")?.includes("collapse")
+      );
+
+    if (expandButtons.length) {
+      const initialRows = screen.getAllByRole("row").length;
+      await userEvent.click(expandButtons[0]);
+      const rowsAfterClick = screen.getAllByRole("row").length;
+
+      // Number of visible rows should change when expanding/collapsing
+      expect(rowsAfterClick).not.toEqual(initialRows);
+    }
+  });
+
+  it("applies initial sortBy configuration", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+        sortBy={[{ id: "release", desc: true }]}
+      />
+    );
+
+    // With desc: true, 18.04 should appear before 16.04
+    const rows = screen.getAllByRole("row");
+    const firstDataRow = rows[1];
+    expect(firstDataRow).toHaveTextContent("18.04 LTS");
+  });
+
+  it("applies variant styles correctly", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+        variant="regular"
+      />
+    );
+
+    const table = screen.getByRole("grid");
+    expect(table).not.toHaveClass("p-generic-table__is-full-height");
+
+    // Render with full-height variant
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+        variant="full-height"
+      />
+    );
+
+    const fullHeightTable = screen.getAllByRole("grid")[1];
+    expect(fullHeightTable).toHaveClass("p-generic-table__is-full-height");
+  });
+
+  it("handles pin groups correctly", () => {
+    // Create data with different architectures for testing pinning
+    const extendedData = [
+      ...data,
+      {
+        id: 2,
+        release: "20.04 LTS",
+        architecture: "armhf",
+        name: "Ubuntu",
+        size: "1.5 MB",
+        lastSynced: "Mon, 06 Jan. 2025 10:45:24",
+        canDeployToMemory: true,
+        status: "Synced",
+        lastDeployed: "Thu, 15 Aug. 2019 06:21:39",
+        machines: 1,
+      },
+    ];
+
+    render(
+      <GenericTable
+        columns={columns}
+        data={extendedData}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        groupBy={["architecture"]}
+        isLoading={false}
+        pinGroup={[{ value: "arm64", isTop: true }]}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // The arm64 groups should be pinned to the top
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("arm64"); // First group row should be arm64
+  });
+
+  it("uses containerRef for calculating table height", () => {
+    // Create a component that uses the containerRef
+    const TestComponent = () => {
+      const containerRef = useRef<HTMLDivElement>(null);
+
+      return (
+        <div ref={containerRef} style={{ height: "500px" }}>
+          <GenericTable
+            columns={columns}
+            containerRef={containerRef}
+            data={data}
+            filterCells={mockFilterCells}
+            filterHeaders={mockFilterHeaders}
+            isLoading={false}
+            rowSelection={{}}
+            setRowSelection={vi.fn()}
+          />
+        </div>
+      );
+    };
+
+    render(<TestComponent />);
+
+    // Verify the table renders correctly with the containerRef
+    expect(screen.getByRole("grid")).toBeInTheDocument();
+
+    // Check that ResizeObserver was created
+    expect(global.ResizeObserver).toHaveBeenCalled();
+
+    // Check that event listeners were added
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+  });
+
+  it("applies filter functions for cells and headers", () => {
+    const customFilterCells = vi.fn(
+      (_row, column) => column.id !== "size" // Filter out the size column cells
+    );
+
+    const customFilterHeaders = vi.fn(
+      (header) => header.id !== "size" // Filter out the size column header
+    );
+
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={customFilterCells}
+        filterHeaders={customFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Size header should not be rendered
+    expect(screen.queryByText("Size")).not.toBeInTheDocument();
+
+    // Size cell values should not be rendered
+    expect(screen.queryByText("1.3 MB")).not.toBeInTheDocument();
+
+    // Other columns should still be visible
+    expect(screen.getByText("Release title")).toBeInTheDocument();
+    expect(screen.getByText("Architecture")).toBeInTheDocument();
+
+    // Verify filter functions were called
+    expect(customFilterCells).toHaveBeenCalled();
+    expect(customFilterHeaders).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/GenericTable/GenericTable.test.tsx
+++ b/src/lib/components/GenericTable/GenericTable.test.tsx
@@ -9,7 +9,7 @@ import GenericTable from "./GenericTable";
 
 import type { PaginationBarProps } from "@/lib/components/GenericTable/PaginationBar";
 
-export type Image = {
+type Image = {
   id: number;
   release: string;
   architecture: string;

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -31,7 +31,9 @@ import {
 import classNames from "classnames";
 
 import ColumnHeader from "@/lib/components/GenericTable/ColumnHeader";
-import PaginationBar, { PaginationBarProps } from "@/lib/components/GenericTable/PaginationBar";
+import PaginationBar, {
+  PaginationBarProps,
+} from "@/lib/components/GenericTable/PaginationBar";
 import TableCheckbox from "@/lib/components/GenericTable/TableCheckbox";
 
 import "./GenericTable.scss";
@@ -168,7 +170,12 @@ const GenericTable = <T extends { id: number | string }>({
         id: "p-generic-table__select",
         accessorKey: "id",
         enableSorting: false,
-        header: "",
+        header: ({ table }: HeaderContext<T, Partial<T>>) => {
+          if (groupBy) {
+            return "";
+          }
+          return <TableCheckbox.All table={table} />;
+        },
         cell: ({ row }: CellContext<T, Partial<T>>) =>
           !row.getIsGrouped() ? <TableCheckbox row={row} /> : null,
       },
@@ -289,10 +296,7 @@ const GenericTable = <T extends { id: number | string }>({
   const renderLoadingRows = () => {
     return (
       <tr>
-        <td
-          className="p-generic-table__loading"
-          colSpan={columns.length}
-        >
+        <td className="p-generic-table__loading" colSpan={columns.length}>
           <Spinner text="Loading..." />
         </td>
       </tr>
@@ -304,10 +308,7 @@ const GenericTable = <T extends { id: number | string }>({
     if (table.getRowModel().rows.length < 1) {
       return (
         <tr>
-          <td
-            className="p-generic-table__no-data"
-            colSpan={columns.length}
-          >
+          <td className="p-generic-table__no-data" colSpan={columns.length}>
             {noData}
           </td>
         </tr>
@@ -341,10 +342,7 @@ const GenericTable = <T extends { id: number | string }>({
               return filterCells(row, cell.column);
             })
             .map((cell) => (
-              <td
-                className={classNames(`${cell.column.id}`)}
-                key={cell.id}
-              >
+              <td className={classNames(`${cell.column.id}`)} key={cell.id}>
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </td>
             ))}
@@ -367,6 +365,7 @@ const GenericTable = <T extends { id: number | string }>({
           itemsPerPage={pagination.itemsPerPage}
           setCurrentPage={pagination.setCurrentPage}
           totalItems={pagination.totalItems}
+          pageSizes={pagination.pageSizes}
         />
       )}
 
@@ -377,6 +376,7 @@ const GenericTable = <T extends { id: number | string }>({
         className={classNames("p-generic-table__table", {
           "p-generic-table__is-full-height": variant === "full-height",
           "p-generic-table__is-selectable": canSelect,
+          "p-generic-table__is-grouped": groupBy !== undefined,
         })}
         role="grid"
       >

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -1,0 +1,417 @@
+import { Fragment, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  RefObject,
+  ReactElement,
+} from "react";
+
+import { Spinner } from "@canonical/react-components";
+import type {
+  Column,
+  Row,
+  ColumnDef,
+  ColumnSort,
+  GroupingState,
+  ExpandedState,
+  SortingState,
+  Header,
+  RowSelectionState,
+  CellContext,
+  HeaderContext,
+} from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getGroupedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import classNames from "classnames";
+
+import ColumnHeader from "@/lib/components/GenericTable/ColumnHeader";
+import PaginationBar, { PaginationBarProps } from "@/lib/components/GenericTable/PaginationBar";
+import TableCheckbox from "@/lib/components/GenericTable/TableCheckbox";
+
+import "./GenericTable.scss";
+
+type GenericTableProps<T extends { id: number | string }> = {
+  className?: string;
+  canSelect?: boolean;
+  columns: ColumnDef<T, Partial<T>>[];
+  containerRef?: RefObject<HTMLElement | null>;
+  data: T[];
+  filterCells?: (row: Row<T>, column: Column<T>) => boolean;
+  filterHeaders?: (header: Header<T, unknown>) => boolean;
+  groupBy?: string[];
+  isLoading: boolean;
+  noData?: ReactNode;
+  pagination?: PaginationBarProps;
+  pinGroup?: { value: string; isTop: boolean }[];
+  sortBy?: ColumnSort[];
+  rowSelection?: RowSelectionState;
+  setRowSelection?: Dispatch<SetStateAction<RowSelectionState>>;
+  variant?: "full-height" | "regular";
+};
+
+/**
+ * GenericTable - A flexible and feature-rich table component for React applications
+ *
+ * A highly customizable table component that supports sorting, grouping, selection,
+ * auto-sizing, and pagination. Built on top of TanStack Table with enhanced features
+ * for enterprise applications.
+ *
+ * @template T - The data type for table rows, must include an 'id' property
+ *
+ * @param {Object} props - Component props
+ * @param {string} [props.className] - Additional CSS class for the table wrapper
+ * @param {boolean} [props.canSelect=false] - Enable row selection with checkboxes
+ * @param {ColumnDef<T, Partial<T>>[]} props.columns - Column definitions
+ * @param {RefObject<HTMLElement | null>} [props.containerRef] - Reference to container for size calculations
+ * @param {T[]} props.data - Table data array
+ * @param {Function} [props.filterCells] - Function to filter which cells should be displayed
+ * @param {Function} [props.filterHeaders] - Function to filter which headers should be displayed
+ * @param {string[]} [props.groupBy] - Column IDs to group rows by
+ * @param {boolean} props.isLoading - Loading state to display placeholder content
+ * @param {ReactNode} [props.noData] - Content to display when no data is available
+ * @param {PaginationBarProps} [props.pagination] - Pagination configuration
+ * @param {{ value: string; isTop: boolean }[]} [props.pinGroup] - Group pinning configuration
+ * @param {ColumnSort[]} [props.sortBy] - Initial sort configuration
+ * @param {RowSelectionState} [props.rowSelection] - Selected rows state
+ * @param {Dispatch<SetStateAction<RowSelectionState>>} [props.setRowSelection] - Selection state setter
+ * @param {"full-height" | "regular"} [props.variant="full-height"] - Table layout variant
+ *
+ * @returns {ReactElement} - The rendered table component
+ *
+ * @example
+ * <GenericTable
+ *   columns={columns}
+ *   data={products}
+ *   isLoading={isLoading}
+ *   canSelect={true}
+ *   groupBy={["category"]}
+ *   rowSelection={selectedRows}
+ *   setRowSelection={setSelectedRows}
+ *   pagination={{
+ *     currentPage: page,
+ *     setCurrentPage: setPage,
+ *     itemsPerPage: pageSize,
+ *     totalItems: totalCount,
+ *     handlePageSizeChange: handlePageSizeChange
+ *   }}
+ * />
+ */
+const GenericTable = <T extends { id: number | string }>({
+  className,
+  canSelect = false,
+  columns: initialColumns,
+  containerRef,
+  data: initialData,
+  filterCells = () => true,
+  filterHeaders = () => true,
+  groupBy,
+  isLoading,
+  noData,
+  pagination,
+  pinGroup,
+  sortBy,
+  rowSelection,
+  setRowSelection,
+  variant = "full-height",
+}: GenericTableProps<T>): ReactElement => {
+  const tableRef = useRef<HTMLTableSectionElement>(null);
+  const [maxHeight, setMaxHeight] = useState("auto");
+
+  const [grouping, setGrouping] = useState<GroupingState>(groupBy ?? []);
+  const [expanded, setExpanded] = useState<ExpandedState>(true);
+  const [sorting, setSorting] = useState<SortingState>(sortBy ?? []);
+
+  // Update table height based on available space
+  useLayoutEffect(() => {
+    const updateHeight = () => {
+      const wrapper = tableRef.current;
+      if (!wrapper) return;
+
+      // Use provided containerRef if available, fallback to main
+      const container = containerRef?.current || document.querySelector("main");
+      if (!container) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const wrapperRect = wrapper.getBoundingClientRect();
+
+      const availableHeight = containerRect.bottom - wrapperRect.top;
+      setMaxHeight(`${availableHeight}px`);
+    };
+
+    updateHeight();
+
+    const resizeObserver = new ResizeObserver(updateHeight);
+    const wrapper = tableRef.current;
+    if (wrapper) resizeObserver.observe(wrapper);
+
+    window.addEventListener("resize", updateHeight);
+    return () => {
+      window.removeEventListener("resize", updateHeight);
+      if (wrapper) resizeObserver.unobserve(wrapper);
+    };
+  }, [containerRef]);
+
+  // Add selection columns if needed
+  const columns = useMemo(() => {
+    if (!canSelect || isLoading) {
+      return initialColumns;
+    }
+
+    const selectionColumns = [
+      {
+        id: "p-generic-table__select",
+        accessorKey: "id",
+        enableSorting: false,
+        header: "",
+        cell: ({ row }: CellContext<T, Partial<T>>) =>
+          !row.getIsGrouped() ? <TableCheckbox row={row} /> : null,
+      },
+      ...initialColumns,
+    ];
+
+    if (groupBy) {
+      return [
+        {
+          id: "p-generic-table__group-select",
+          accessorKey: "id",
+          enableSorting: false,
+          header: ({ table }: HeaderContext<T, Partial<T>>) => (
+            <TableCheckbox.All table={table} />
+          ),
+          cell: ({ row }: CellContext<T, Partial<T>>) =>
+            row.getIsGrouped() ? <TableCheckbox.Group row={row} /> : null,
+        },
+        ...selectionColumns,
+      ];
+    }
+
+    return selectionColumns;
+  }, [canSelect, initialColumns, isLoading, groupBy]);
+
+  // Memoize grouped data
+  const groupedData = useMemo(() => {
+    if (!grouping.length) return initialData;
+
+    return [...initialData].sort((a, b) => {
+      // Sort by group values
+      for (const groupId of grouping) {
+        const aGroupValue = a[groupId as keyof typeof a] ?? null;
+        const bGroupValue = b[groupId as keyof typeof b] ?? null;
+
+        if (aGroupValue === null) return 1;
+        if (bGroupValue === null) return -1;
+
+        if (aGroupValue < bGroupValue) return -1;
+        if (aGroupValue > bGroupValue) return 1;
+      }
+      return 0;
+    });
+  }, [initialData, grouping]);
+
+  // Sort data based on pinning and sorting preferences
+  const sortedData = useMemo(() => {
+    if (!groupedData.length) return [];
+
+    return [...groupedData].sort((a, b) => {
+      // Handle pinned groups
+      if (pinGroup?.length && grouping.length) {
+        for (const { value, isTop } of pinGroup) {
+          const groupId = grouping[0];
+          const aValue = a[groupId as keyof typeof a] ?? null;
+          const bValue = b[groupId as keyof typeof b] ?? null;
+
+          if (aValue === value && bValue !== value) {
+            return isTop ? -1 : 1;
+          }
+          if (bValue === value && aValue !== value) {
+            return isTop ? 1 : -1;
+          }
+        }
+      }
+
+      // Sort by column sorting
+      for (const { id, desc } of sorting) {
+        const aValue = a[id as keyof typeof a] ?? null;
+        const bValue = b[id as keyof typeof b] ?? null;
+
+        // Handle null values
+        if (aValue === null && bValue === null) return 0;
+        if (aValue === null) return desc ? -1 : 1;
+        if (bValue === null) return desc ? 1 : -1;
+
+        if (aValue < bValue) {
+          return desc ? 1 : -1;
+        }
+        if (aValue > bValue) {
+          return desc ? -1 : 1;
+        }
+      }
+
+      return 0;
+    });
+  }, [groupedData, sorting, pinGroup, grouping]);
+
+  // Configure table
+  const table = useReactTable<T>({
+    data: sortedData,
+    columns,
+    state: {
+      grouping,
+      expanded,
+      sorting,
+      rowSelection,
+    },
+    manualPagination: true,
+    autoResetExpanded: false,
+    onExpandedChange: setExpanded,
+    onSortingChange: setSorting,
+    onGroupingChange: setGrouping,
+    onRowSelectionChange: setRowSelection,
+    manualSorting: true,
+    enableSorting: true,
+    enableExpanding: true,
+    getExpandedRowModel: getExpandedRowModel(),
+    getCoreRowModel: getCoreRowModel(),
+    getGroupedRowModel: getGroupedRowModel(),
+    groupedColumnMode: false,
+    enableRowSelection: canSelect,
+    enableMultiRowSelection: canSelect,
+    getRowId: (originalRow) => originalRow.id.toString(),
+  });
+
+  // Render loading placeholder rows
+  const renderLoadingRows = () => {
+    return (
+      <tr>
+        <td
+          className="p-generic-table__loading"
+          colSpan={columns.length}
+        >
+          <Spinner text="Loading..." />
+        </td>
+      </tr>
+    );
+  };
+
+  // Render data rows
+  const renderDataRows = () => {
+    if (table.getRowModel().rows.length < 1) {
+      return (
+        <tr>
+          <td
+            className="p-generic-table__no-data"
+            colSpan={columns.length}
+          >
+            {noData}
+          </td>
+        </tr>
+      );
+    }
+
+    return table.getRowModel().rows.map((row) => {
+      const { getIsGrouped, id, getVisibleCells } = row;
+      const isIndividualRow = !getIsGrouped();
+      const isSelected =
+        rowSelection !== undefined && Object.keys(rowSelection!).includes(id);
+
+      return (
+        <tr
+          aria-rowindex={parseInt(id.replace(/\D/g, "") || "0", 10) + 1}
+          aria-selected={isSelected}
+          className={classNames({
+            "p-generic-table__individual-row": isIndividualRow,
+            "p-generic-table__group-row": !isIndividualRow,
+          })}
+          key={id}
+          role="row"
+        >
+          {getVisibleCells()
+            .filter((cell) => {
+              if (
+                !isIndividualRow &&
+                cell.column.id === "p-generic-table__group-select"
+              )
+                return true;
+              return filterCells(row, cell.column);
+            })
+            .map((cell) => (
+              <td
+                className={classNames(`${cell.column.id}`)}
+                key={cell.id}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </td>
+            ))}
+        </tr>
+      );
+    });
+  };
+
+  return (
+    <div
+      className={classNames("p-generic-table", className)}
+      data-testid="p-generic-table"
+    >
+      {pagination && (
+        <PaginationBar
+          currentPage={pagination.currentPage}
+          dataContext={pagination.dataContext}
+          handlePageSizeChange={pagination.handlePageSizeChange}
+          isPending={pagination.isPending}
+          itemsPerPage={pagination.itemsPerPage}
+          setCurrentPage={pagination.setCurrentPage}
+          totalItems={pagination.totalItems}
+        />
+      )}
+
+      <table
+        aria-busy={isLoading}
+        aria-describedby="generic-table-description"
+        aria-rowcount={sortedData.length + 1} // +1 for header row
+        className={classNames("p-generic-table__table", {
+          "p-generic-table__is-full-height": variant === "full-height",
+          "p-generic-table__is-selectable": canSelect,
+        })}
+        role="grid"
+      >
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id} role="row">
+              {headerGroup.headers
+                .filter(filterHeaders)
+                .map((header, index) => (
+                  <Fragment key={header.id}>
+                    <ColumnHeader header={header} />
+                    {index === 2 ? (
+                      <th
+                        className="p-generic-table__select-alignment"
+                        role="columnheader"
+                      />
+                    ) : null}
+                  </Fragment>
+                ))}
+            </tr>
+          ))}
+        </thead>
+
+        <tbody
+          ref={tableRef}
+          style={{
+            overflowY: "auto",
+            maxHeight,
+          }}
+        >
+          {isLoading ? renderLoadingRows() : renderDataRows()}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default GenericTable;

--- a/src/lib/components/GenericTable/GroupRowActions/GroupRowActions.test.tsx
+++ b/src/lib/components/GenericTable/GroupRowActions/GroupRowActions.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import GroupRowActions from "./GroupRowActions";
+
+const getMockRow = (isExpanded: boolean) => {
+  return {
+    getIsExpanded: vi.fn(() => isExpanded),
+    toggleExpanded: vi.fn(),
+  };
+};
+
+it("calls toggleExpanded when button is clicked", async () => {
+  const mockRow = getMockRow(true);
+  // @ts-expect-error a `Row` has 36 properties, which is a lot to mock, so we've only mocked the ones we need
+  render(<GroupRowActions row={mockRow} />);
+
+  await userEvent.click(screen.getByRole("button"));
+  expect(mockRow.toggleExpanded).toHaveBeenCalled();
+});
+
+it('displays "Collapse" when expanded', () => {
+  const mockRow = getMockRow(true);
+  // @ts-expect-error see above comment
+  render(<GroupRowActions row={mockRow} />);
+  expect(screen.getByText("Collapse")).toBeInTheDocument();
+});
+
+it('displays "Expand" when not expanded', () => {
+  const mockRow = getMockRow(false);
+  // @ts-expect-error see above comment
+  render(<GroupRowActions row={mockRow} />);
+  expect(screen.getByText("Expand")).toBeInTheDocument();
+});

--- a/src/lib/components/GenericTable/GroupRowActions/GroupRowActions.tsx
+++ b/src/lib/components/GenericTable/GroupRowActions/GroupRowActions.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from "react";
+
+import { Button, Icon } from "@canonical/react-components";
+import type { Row } from "@tanstack/react-table";
+
+type GroupRowActionsProps<T> = {
+  row: Row<T>;
+};
+
+const GroupRowActions = <T,>({
+  row,
+}: GroupRowActionsProps<T>): ReactElement => {
+  return (
+    <Button
+      appearance="base"
+      dense
+      hasIcon
+      onClick={() => {
+        row.toggleExpanded();
+      }}
+      type="button"
+    >
+      {row.getIsExpanded() ? (
+        <Icon name="minus">Collapse</Icon>
+      ) : (
+        <Icon name="plus">Expand</Icon>
+      )}
+    </Button>
+  );
+};
+
+export default GroupRowActions;

--- a/src/lib/components/GenericTable/GroupRowActions/index.ts
+++ b/src/lib/components/GenericTable/GroupRowActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GroupRowActions";

--- a/src/lib/components/GenericTable/PaginationBar/ControlsBar/ControlsBar.tsx
+++ b/src/lib/components/GenericTable/PaginationBar/ControlsBar/ControlsBar.tsx
@@ -1,0 +1,26 @@
+import type { PropsWithChildren, ReactElement } from "react";
+
+const ControlsBar = ({ children }: PropsWithChildren<object>): ReactElement => {
+  return (
+    <section className="controls-bar u-flex u-flex--justify-between u-flex--wrap">
+      <div className="p-form p-form--inline">{children}</div>
+    </section>
+  );
+};
+
+const ControlsBarLeft = ({ children }: PropsWithChildren<object>) => {
+  return <strong className="controls-bar__description">{children}</strong>;
+};
+
+const ControlsBarRight = ({ children }: PropsWithChildren<object>) => {
+  return (
+    <div className="u-flex u-flex--wrap u-flex--column-x-small controls-bar__right">
+      {children}
+    </div>
+  );
+};
+
+ControlsBar.Left = ControlsBarLeft;
+ControlsBar.Right = ControlsBarRight;
+
+export default ControlsBar;

--- a/src/lib/components/GenericTable/PaginationBar/ControlsBar/index.ts
+++ b/src/lib/components/GenericTable/PaginationBar/ControlsBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ControlsBar";

--- a/src/lib/components/GenericTable/PaginationBar/PaginationBar.tsx
+++ b/src/lib/components/GenericTable/PaginationBar/PaginationBar.tsx
@@ -14,8 +14,8 @@ export type PaginationBarProps = {
   dataContext: string;
   setCurrentPage: (page: number) => void;
   isPending: boolean;
+  pageSizes?: number[];
 };
-export const pageSizes: number[] = [20, 30, 50, 100];
 
 const PaginationBar = ({
   currentPage,
@@ -25,6 +25,7 @@ const PaginationBar = ({
   dataContext,
   setCurrentPage,
   isPending,
+  pageSizes = [20, 30, 50, 100],
 }: PaginationBarProps): ReactElement => {
   const pageCounts = useMemo(() => pageSizes, []);
   const pageOptions = useMemo(
@@ -33,7 +34,7 @@ const PaginationBar = ({
         label: `${pageCount}/page`,
         value: pageCount,
       })),
-    [pageCounts]
+    [pageCounts],
   );
 
   const totalPages = Math.ceil(totalItems / itemsPerPage);

--- a/src/lib/components/GenericTable/PaginationBar/PaginationBar.tsx
+++ b/src/lib/components/GenericTable/PaginationBar/PaginationBar.tsx
@@ -1,0 +1,81 @@
+import type { ChangeEvent, ReactElement } from "react";
+import { useMemo } from "react";
+
+import { Select } from "@canonical/react-components";
+
+import ControlsBar from "@/lib/components/GenericTable/PaginationBar/ControlsBar";
+import { PaginationContainer } from "@/lib/components/Pagination";
+
+export type PaginationBarProps = {
+  currentPage: number;
+  itemsPerPage: number;
+  totalItems: number;
+  handlePageSizeChange: (size: number) => void;
+  dataContext: string;
+  setCurrentPage: (page: number) => void;
+  isPending: boolean;
+};
+export const pageSizes: number[] = [20, 30, 50, 100];
+
+const PaginationBar = ({
+  currentPage,
+  itemsPerPage,
+  totalItems,
+  handlePageSizeChange,
+  dataContext,
+  setCurrentPage,
+  isPending,
+}: PaginationBarProps): ReactElement => {
+  const pageCounts = useMemo(() => pageSizes, []);
+  const pageOptions = useMemo(
+    () =>
+      pageCounts.map((pageCount) => ({
+        label: `${pageCount}/page`,
+        value: pageCount,
+      })),
+    [pageCounts]
+  );
+
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  const handleSizeChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value } = e.target;
+    handlePageSizeChange(Number(value));
+  };
+
+  const getDisplayedDataCount = () => {
+    if (currentPage === totalPages) {
+      return itemsPerPage - (totalPages * itemsPerPage - totalItems);
+    } else if (currentPage < totalPages) {
+      return itemsPerPage;
+    } else {
+      return 0;
+    }
+  };
+
+  return (
+    <ControlsBar>
+      <ControlsBar.Left>
+        Showing {getDisplayedDataCount()} out of {totalItems} {dataContext}
+      </ControlsBar.Left>
+      <ControlsBar.Right>
+        <PaginationContainer
+          currentPage={currentPage}
+          disabled={isPending}
+          paginate={setCurrentPage}
+          totalPages={totalPages}
+        />
+        <Select
+          aria-label="Items per page"
+          className="u-no-margin--bottom"
+          name="Items per page"
+          onChange={handleSizeChange}
+          options={pageOptions}
+          value={itemsPerPage}
+        />
+      </ControlsBar.Right>
+    </ControlsBar>
+  );
+};
+
+export default PaginationBar;

--- a/src/lib/components/GenericTable/PaginationBar/index.ts
+++ b/src/lib/components/GenericTable/PaginationBar/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PaginationBar";
+export type { PaginationBarProps } from "./PaginationBar";

--- a/src/lib/components/GenericTable/SortingIndicator/SortingIndicator.tsx
+++ b/src/lib/components/GenericTable/SortingIndicator/SortingIndicator.tsx
@@ -1,0 +1,18 @@
+import type { ReactElement } from "react";
+
+import { Icon } from "@canonical/react-components";
+import type { Header } from "@tanstack/react-table";
+
+type SortingIndicatorProps<T> = {
+  header: Header<T, unknown>;
+};
+
+const SortingIndicator = <T,>({
+  header,
+}: SortingIndicatorProps<T>): ReactElement | null =>
+  ({
+    asc: <Icon name={"chevron-up"}>ascending</Icon>,
+    desc: <Icon name={"chevron-down"}>descending</Icon>,
+  })[header?.column?.getIsSorted() as string] ?? null;
+
+export default SortingIndicator;

--- a/src/lib/components/GenericTable/SortingIndicator/index.ts
+++ b/src/lib/components/GenericTable/SortingIndicator/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SortingIndicator";

--- a/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
+++ b/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
@@ -6,8 +6,18 @@ import type { Mock } from "vitest";
 
 import TableCheckbox from "./TableCheckbox";
 
-import { Image } from "@/lib/components/GenericTable/GenericTable.test";
-
+type Image = {
+  id: number;
+  release: string;
+  architecture: string;
+  name: string;
+  size: string;
+  lastSynced: string | null;
+  canDeployToMemory: boolean;
+  status: string;
+  lastDeployed: string;
+  machines: number;
+};
 const getMockRow = (rowProps: Partial<Row<Image>> = {}) => {
   return Object.assign(
     {

--- a/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
+++ b/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
@@ -1,0 +1,174 @@
+import type { Row } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, vi } from "vitest";
+import type { Mock } from "vitest";
+
+import TableCheckbox from "./TableCheckbox";
+
+import { Image } from "@/lib/components/GenericTable/GenericTable.test";
+
+const getMockRow = (rowProps: Partial<Row<Image>> = {}) => {
+  return Object.assign(
+    {
+      getIsSelected: vi.fn(() => false),
+      getIsAllSubRowsSelected: vi.fn(() => false),
+      getIsSomeSelected: vi.fn(() => false),
+      getCanSelect: vi.fn(() => true),
+      getIsGrouped: vi.fn(() => true),
+      toggleSelected: vi.fn(),
+      subRows: [
+        {
+          toggleSelected: vi.fn(),
+          id: 0,
+          release: "16.04 LTS",
+          architecture: "amd64",
+          name: "Ubuntu",
+          size: "1.3 MB",
+          lastSynced: "Mon, 06 Jan. 2025 10:45:24",
+          canDeployToMemory: true,
+          status: "Synced",
+        },
+        {
+          toggleSelected: vi.fn(),
+          id: 1,
+          release: "18.04 LTS",
+          architecture: "arm64",
+          name: "Ubuntu",
+          size: "1.3 MB",
+          lastSynced: "Mon, 06 Jan. 2025 10:45:24",
+          canDeployToMemory: true,
+          status: "Synced",
+        },
+      ],
+    },
+    rowProps,
+  );
+};
+
+describe("TableCheckbox.All", () => {
+  const renderSelectAllCheckbox = (tableProps?: {
+    getSelectedRowModel: Mock;
+    getCoreRowModel: Mock;
+  }) => {
+    const mockTable = {
+      getSelectedRowModel: vi.fn(() => ({ rows: [] })),
+      getCoreRowModel: vi.fn(() => ({ rows: [] })),
+      toggleAllPageRowsSelected: vi.fn(),
+      getIsAllPageRowsSelected: vi.fn(() => false),
+      ...tableProps,
+    };
+
+    // @ts-expect-error we're not mocking the entire table object, just the parts we need
+    return { ...render(<TableCheckbox.All table={mockTable} />), mockTable };
+  };
+
+  it("displays 'unchecked' when no rows are selected", () => {
+    renderSelectAllCheckbox();
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("displays 'mixed' state when some rows are selected", () => {
+    renderSelectAllCheckbox({
+      getSelectedRowModel: vi.fn(() => ({ rows: [{}] })), // 1 row selected
+      getCoreRowModel: vi.fn(() => ({ rows: [{}, {}] })),
+    });
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-checked",
+      "mixed",
+    );
+  });
+
+  it("displays 'checked' when all rows are selected", () => {
+    renderSelectAllCheckbox({
+      getSelectedRowModel: vi.fn(() => ({ rows: [{}] })), // Simulate all rows selected
+      getCoreRowModel: vi.fn(() => ({ rows: [{}] })),
+    });
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("toggles all rows on click", async () => {
+    const { mockTable } = renderSelectAllCheckbox();
+    await userEvent.click(screen.getByRole("checkbox"));
+    expect(mockTable.toggleAllPageRowsSelected).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("TableCheckbox.Group", () => {
+  const renderSelectGroupCheckbox = (rowProps: Partial<Row<Image>> = {}) => {
+    const mockRow = getMockRow(rowProps);
+    return { ...render(<TableCheckbox.Group row={mockRow} />), ...mockRow };
+  };
+
+  it("is enabled when row can be selected", () => {
+    renderSelectGroupCheckbox({ getCanSelect: vi.fn(() => true) });
+    expect(screen.getByRole("checkbox")).toBeEnabled();
+  });
+
+  it("is disabled when row cannot be selected", () => {
+    renderSelectGroupCheckbox({ getCanSelect: vi.fn(() => false) });
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  it("toggles selection state on click", async () => {
+    const { subRows, toggleSelected } = renderSelectGroupCheckbox();
+    await userEvent.click(screen.getByRole("checkbox"));
+    expect(toggleSelected).toHaveBeenCalledWith(true);
+    expect(subRows[0].toggleSelected).toHaveBeenCalledWith(true);
+    expect(subRows[1].toggleSelected).toHaveBeenCalledWith(true);
+  });
+
+  it("sets mixed state correctly", () => {
+    renderSelectGroupCheckbox({ getIsSomeSelected: () => true });
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-checked",
+      "mixed",
+    );
+  });
+
+  it("toggles all sub-rows when in mixed state", async () => {
+    const { subRows } = renderSelectGroupCheckbox({
+      getIsSomeSelected: () => true,
+    });
+
+    await userEvent.click(screen.getByRole("checkbox"));
+    subRows.forEach((subRow: Row<Image>) => {
+      expect(subRow.toggleSelected).toHaveBeenCalledWith(true);
+    });
+  });
+});
+
+describe("TableCheckbox", () => {
+  const renderIndividualCheckbox = (rowProps: Partial<Row<Image>> = {}) => {
+    const mockRow = {
+      getIsSelected: vi.fn(() => false),
+      getCanSelect: vi.fn(() => true),
+      getToggleSelectedHandler: vi.fn(),
+      ...rowProps,
+    };
+    // @ts-expect-error we're not mocking the entire row object, just the parts we need
+    return { ...render(<TableCheckbox row={mockRow} />), mockRow };
+  };
+
+  it("is enabled when row can be selected", () => {
+    renderIndividualCheckbox();
+    expect(screen.getByRole("checkbox")).toBeEnabled();
+  });
+
+  it("is disabled when row cannot be selected", () => {
+    renderIndividualCheckbox({ getCanSelect: vi.fn(() => false) });
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  it("calls the toggle handler on click", async () => {
+    const { mockRow } = renderIndividualCheckbox();
+    await userEvent.click(screen.getByRole("checkbox"));
+    expect(mockRow.getToggleSelectedHandler).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
+++ b/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
@@ -1,0 +1,120 @@
+import type {
+  DetailedHTMLProps,
+  InputHTMLAttributes,
+  ReactElement,
+} from "react";
+
+import type { Row, Table } from "@tanstack/react-table";
+
+type TableCheckboxProps<T> = Partial<
+  DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>
+> & {
+  row?: Row<T>;
+  table?: Table<T>;
+};
+
+const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
+  if (!table) {
+    return null;
+  }
+
+  let checked: boolean | "false" | "mixed" | "true" | undefined;
+  if (table.getSelectedRowModel().rows.length === 0) {
+    checked = "false";
+  } else if (
+    table.getSelectedRowModel().rows.length <
+    table.getCoreRowModel().rows.length
+  ) {
+    checked = "mixed";
+  } else {
+    checked = "true";
+  }
+
+  return (
+    <label className="p-checkbox--inline p-table-checkbox--all">
+      <input
+        aria-checked={checked}
+        aria-label="select all"
+        className="p-checkbox__input"
+        type="checkbox"
+        {...{
+          checked: checked === "true",
+          onChange: () => {
+            if (table.getIsAllPageRowsSelected()) {
+              table?.toggleAllPageRowsSelected(false);
+            } else {
+              table?.toggleAllPageRowsSelected(true);
+            }
+          },
+        }}
+        {...props}
+      />
+      <span className="p-checkbox__label" />
+    </label>
+  );
+};
+
+const TableGroupCheckbox = <T,>({ row, ...props }: TableCheckboxProps<T>) => {
+  if (!row) {
+    return null;
+  }
+  const isSomeSubRowsSelected =
+    !row.getIsAllSubRowsSelected() && row.getIsSomeSelected();
+  return (
+    <label className="p-checkbox--inline p-table-checkbox--group">
+      <input
+        aria-checked={isSomeSubRowsSelected ? "mixed" : undefined}
+        className="p-checkbox__input"
+        type="checkbox"
+        {...{
+          checked: isSomeSubRowsSelected || row.getIsAllSubRowsSelected(),
+          disabled: !row.getCanSelect(),
+          onChange: () => {
+            if (row?.getIsAllSubRowsSelected()) {
+              row?.toggleSelected(false);
+              row.subRows.forEach((subRow) => {
+                subRow.toggleSelected(false);
+              });
+            } else {
+              row?.toggleSelected(true);
+              row.subRows.forEach((subRow) => {
+                subRow.toggleSelected(true);
+              });
+            }
+          },
+        }}
+        {...props}
+      />
+      <span className="p-checkbox__label" />
+    </label>
+  );
+};
+
+const TableCheckbox = <T,>({
+  row,
+  ...props
+}: TableCheckboxProps<T>): ReactElement | null => {
+  if (!row) {
+    return null;
+  }
+  return (
+    <label className="p-checkbox--inline p-table-checkbox">
+      <input
+        className="p-checkbox__input"
+        type="checkbox"
+        {...{
+          checked: row.getIsSelected(),
+          disabled: !row.getCanSelect(),
+          onChange: row.getToggleSelectedHandler(),
+        }}
+        {...props}
+      />
+      <span className="p-checkbox__label" />
+    </label>
+  );
+};
+
+TableCheckbox.All = TableAllCheckbox;
+TableCheckbox.Group = TableGroupCheckbox;
+
+export default TableCheckbox;

--- a/src/lib/components/GenericTable/TableCheckbox/index.ts
+++ b/src/lib/components/GenericTable/TableCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TableCheckbox";

--- a/src/lib/components/GenericTable/index.ts
+++ b/src/lib/components/GenericTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GenericTable";


### PR DESCRIPTION
## Done

- Upstreamed GenericTable with accompanying subcomponents
- Created stories for GenericTable
- Added more specific styling formerly handled by maas-ui
- Made  TableCheckbox.All visible for ungrouped selectable tables
- Forced pagination to flex row alignement
- Added the list of page size choices as a pagination prop

## QA steps

- [ ]  Ensure the component is displayed correctly across all breakpoints
- [ ] Check the stories for GenericTable

## Fixes

Resolves: 

[MAASENG-4794](https://warthogs.atlassian.net/browse/MAASENG-4794)


[MAASENG-4794]: https://warthogs.atlassian.net/browse/MAASENG-4794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ