### PR TITLE
fix(components): Fix paginated expansion bug MAASENG-5326

### DIFF
--- a/src/lib/components/GenericTable/GenericTable.scss
+++ b/src/lib/components/GenericTable/GenericTable.scss
@@ -105,6 +105,10 @@
 
         background-color: $colors--light-theme--background-hover;
       }
+
+      tr.p-generic-table__group-row {
+        cursor: pointer;
+      }
     }
 
     // Selection column styling

--- a/src/lib/components/GenericTable/GenericTable.scss
+++ b/src/lib/components/GenericTable/GenericTable.scss
@@ -92,7 +92,7 @@
       height: auto;
       min-height: auto;
 
-      td:last-child {
+      tr:not(.p-generic-table__group-row) > td:last-child {
         text-align: right;
       }
     }
@@ -112,6 +112,7 @@
     }
 
     // Selection column styling
+    .p-generic-table__group-chevron,
     .p-generic-table__group-select,
     .p-generic-table__select,
     .p-generic-table__select-alignment {

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -62,7 +62,7 @@ const generateNestedMachinesData = (count: number): Machine[] => {
   flatMachineData.forEach((machine) => {
     if (machine.pool === "default") {
       const children = flatMachineData.filter(
-        (r) => r.pool !== "default" && r.zone === machine.zone
+        (r) => r.pool !== "default" && r.zone === machine.zone,
       );
       if (children.length > 0) {
         machine.children = children;
@@ -115,16 +115,13 @@ const machineColumns: MachineColumnDef[] = [
     id: "actions",
     accessorKey: "id",
     header: "Actions",
-    cell: ({ row }: { row: Row<Machine> }) => {
-      if (row.getIsGrouped()) return <GroupRowActions row={row} />;
-      return (
-        <div className="actions-cell">
-          <Button appearance="base" hasIcon>
-            <Icon name="delete" />
-          </Button>
-        </div>
-      );
-    },
+    cell: () => (
+      <div className="actions-cell">
+        <Button appearance="base" hasIcon>
+          <Icon name="delete" />
+        </Button>
+      </div>
+    ),
   },
 ];
 
@@ -256,6 +253,16 @@ const meta: Meta<typeof GenericTable<Machine>> = {
       control: false,
       table: {
         type: { summary: "{ value: string; isTop: boolean }[]" },
+        category: "Grouping",
+      },
+    },
+    showChevron: {
+      description:
+        "Boolean to show group expansion chevrons at the start of group rows",
+      control: { type: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
         category: "Grouping",
       },
     },
@@ -487,7 +494,7 @@ export const Grouped: Story = {
     groupBy: ["status"],
     filterCells: (row: Row<Machine>, column: Column<Machine>): boolean => {
       if (row.getIsGrouped()) {
-        return ["status", "actions"].includes(column.id);
+        return ["status"].includes(column.id);
       } else {
         return !["status"].includes(column.id);
       }
@@ -567,7 +574,7 @@ export const GroupedSelectable: Story = {
     groupBy: ["status"],
     filterCells: (row: Row<Machine>, column: Column<Machine>): boolean => {
       if (row.getIsGrouped()) {
-        return ["status", "actions"].includes(column.id);
+        return ["status"].includes(column.id);
       } else {
         return !["status"].includes(column.id);
       }

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -361,8 +361,13 @@ export const GenericTable = <T extends { id: number | string }>({
           className={classNames({
             "p-generic-table__individual-row": isIndividualRow,
             "p-generic-table__group-row": !isIndividualRow,
-            "p-generic-table__nested-row": getSubRows !== undefined && !!parentId,
+            "p-generic-table__nested-row":
+              getSubRows !== undefined && !!parentId,
           })}
+          onClick={() => {
+            if (isIndividualRow) return;
+            row.toggleExpanded();
+          }}
           key={id}
           role="row"
         >

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -14,7 +14,7 @@ import {
   useState,
 } from "react";
 
-import { Icon, ICONS, Spinner } from "@canonical/react-components";
+import { Icon, ICONS, Spinner, Tooltip } from "@canonical/react-components";
 import type {
   CellContext,
   Column,
@@ -253,11 +253,16 @@ export const GenericTable = <T extends { id: number | string }>({
         enableSorting: false,
         header: "",
         cell: ({ row }: CellContext<T, Partial<T>>) => {
+          const isExpanded = row.getIsExpanded();
           if (row.getIsGrouped()) {
             return (
-              <Icon
-                name={row.getIsExpanded() ? ICONS.chevronDown : ICONS.chevronUp}
-              />
+              <Tooltip message={isExpanded ? "Collapse" : "Expand"} position="btm-right">
+                <Icon
+                  name={
+                    isExpanded ? ICONS.chevronDown : ICONS.chevronUp
+                  }
+                />
+              </Tooltip>
             );
           }
           return null;

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -469,7 +469,10 @@ export const GenericTable = <T extends { id: number | string }>({
                 .map((header, index) => (
                   <Fragment key={header.id}>
                     <ColumnHeader header={header} />
-                    {canSelect && groupBy && index === 3 ? (
+                    {canSelect &&
+                    groupBy &&
+                    ((!showChevron && index === 2) ||
+                      (showChevron && index === 3)) ? (
                       <th
                         className="p-generic-table__select-alignment"
                         role="columnheader"

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -259,7 +259,7 @@ export const GenericTable = <T extends { id: number | string }>({
               <Tooltip message={isExpanded ? "Collapse" : "Expand"} position="btm-right">
                 <Icon
                   name={
-                    isExpanded ? ICONS.chevronDown : ICONS.chevronUp
+                    isExpanded ? ICONS.chevronUp : ICONS.chevronDown
                   }
                 />
               </Tooltip>


### PR DESCRIPTION
## Done
- Added onClick to the entire group row to toggle expansion
- Added optional chevron to display group expansion state
- Fixed paginated group expansion bug

## QA steps

- [x] Ensure the component is displayed correctly across all breakpoints

- [x] Verify clicking anywhere on a group row toggles its expansion state

- [x] Set showChevron to true for both selectable and non-selectable grouped tables
- [x] Verify the alignments and chevrons are correct

- [x] Verify that collapse states persist across pages, and newly encountered groups default to expanded

## Fixes

Fixes: 

[MAASENG-5326](https://warthogs.atlassian.net/browse/MAASENG-5326)

## Notes

You can use the following changes to the GroupedSelectable story to test the changes.

```ts
export const GroupedSelectable: Story = {
  name: "Grouped (Selectable)",
  render: (args) => {
    const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
    const [currentPage, setCurrentPage] = useState(1);
    const [itemsPerPage, setItemsPerPage] = useState(5);
    const startIndex = (currentPage - 1) * itemsPerPage;
    const data = generateMachinesData(20);
    data.sort((a, b) => {
      return a.status > b.status ? 1 : a.status < b.status ? -1 : 0;
    });
    const paginatedData = data.slice(startIndex, startIndex + itemsPerPage);

    const handlePageSizeChange = (size: number) => {
      setItemsPerPage(size);
      setCurrentPage(1);
    };

    return (
      <div style={{ width: "100%" }}>
        <div
          style={{
            width: "100%",
            display: "flex",
            justifyContent: "space-between",
            marginBottom: "1rem",
          }}
        >
          <h5>
            Selected machines:{" "}
            {
              Object.keys(rowSelection).filter(
                (key: string) => !isNaN(Number(key)),
              ).length
            }
          </h5>
          <div className="p-button-group">
            <Button
              appearance="negative"
              disabled={Object.keys(rowSelection).length === 0}
            >
              Delete
            </Button>
          </div>
        </div>
        <GenericTable
          {...args}
          data={paginatedData}
          pagination={{
            currentPage,
            setCurrentPage,
            itemsPerPage,
            totalItems: data.length,
            handlePageSizeChange,
            dataContext: "machines",
            isPending: false,
            pageSizes: [5, 10, 20],
          }}
          rowSelection={rowSelection}
          setRowSelection={setRowSelection}
        />
      </div>
    );
  },
  args: {
    canSelect: true,
    columns: [
      {
        id: "status",
        accessorKey: "status",
        cell: ({
          row,
          getValue,
        }: {
          row: Row<Machine>;
          getValue: Getter<string>;
        }) => {
          return (
            <div>
              <div>
                <strong>{getValue()}</strong>
              </div>
              <small className="u-text--muted">
                {`${row.getLeafRows().length} machine${row.getLeafRows().length > 1 ? "s" : ""}`}
              </small>
            </div>
          );
        },
      },
      ...machineColumns.filter((column) => column.id !== "status"),
    ],
    groupBy: ["status"],
    filterCells: (row: Row<Machine>, column: Column<Machine>): boolean => {
      if (row.getIsGrouped()) {
        return ["status"].includes(column.id);
      } else {
        return !["status"].includes(column.id);
      }
    },
    filterHeaders: (header: Header<Machine, unknown>): boolean =>
      header.column.id !== "status",
  },
};
```

[MAASENG-5326]: https://warthogs.atlassian.net/browse/MAASENG-5326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ