### PR TITLE
fix(Stepper): Use correct counter syntax and proper dark theming

### DIFF
--- a/src/lib/components/Stepper/Stepper.scss
+++ b/src/lib/components/Stepper/Stepper.scss
@@ -10,11 +10,13 @@ $height: 1.5rem;
 
 .stepper {
   margin-bottom: $spv--medium;
+  counter-reset: count 0;
 
   @extend .p-stepped-list;
 
   .stepper__item {
     @extend .p-stepped-list__item;
+    counter-increment: count 1;
 
     padding-bottom: $spv--x-small;
     width: auto;
@@ -31,7 +33,7 @@ $height: 1.5rem;
     padding-left: $padding-left;
 
     &::before {
-      content: counter(li);
+      content: counter(count);
       border-radius: 50%;
       text-align: center;
       background-color: $color-light;
@@ -62,5 +64,20 @@ $height: 1.5rem;
       position: absolute;
       top: $top;
     }
+  }
+}
+
+.is-dark {
+  .stepper__title::before {
+      background-color: $color-dark;
+  } 
+  
+  .stepper__title--is-active::before {
+      background-color: $color-x-light;
+      color: $color-dark;
+  }
+
+  .stepper__title--is-complete::after {
+    @include vf-icon-task-outstanding($color-x-light);
   }
 }

--- a/src/lib/components/Stepper/Stepper.scss
+++ b/src/lib/components/Stepper/Stepper.scss
@@ -16,8 +16,8 @@ $height: 1.5rem;
 
   .stepper__item {
     @extend .p-stepped-list__item;
-    counter-increment: count 1;
 
+    counter-increment: count 1;
     padding-bottom: $spv--x-small;
     width: auto;
 

--- a/src/lib/sections/ContentSection/ContentSection.scss
+++ b/src/lib/sections/ContentSection/ContentSection.scss
@@ -19,6 +19,7 @@ section.content-section {
     border-top: $border;
     padding: $footer-padding 0 0 0;
     text-align: right;
+    background-color: var(--vf-color-background-default);
 
     // Reduce the margin of all direct descendants for consistent spacing
     > * {


### PR DESCRIPTION
## Done
- Fixed counter syntax in stepper
- Adjusted text, icon, and background colours to work properly with dark mode
- (driveby) give content section footer a solid background to prevent seeing content behind footer

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Ensure the component is displayed correctly across all breakpoints
- [x] Go to the Stepper story
- [x] Ensure the circled numbers are correct (1, 2, 3)
- [x] Link this package to MAAS UI (instructions in readme)
- [x] Run MAAS UI and go to the LXD page
- [x] Click "Add LXD host"
- [x] Enable dark mode
- [x] Ensure the stepper text is readable against the dark background
- [x] Complete the first step (doesn't have to be a real IP address)
- [x] Ensure the tick icon is white

## Screenshots
<img width="240" height="180" alt="image" src="https://github.com/user-attachments/assets/6c61d4c2-a54a-4863-861c-ec19e49b0ecd" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
