### PR TITLE
fix(FileUpload): Fix FileUpload file explorer trigger and file removal MAASENG-5932

### DIFF
--- a/src/lib/components/FileUpload/FileUpload.scss
+++ b/src/lib/components/FileUpload/FileUpload.scss
@@ -61,6 +61,10 @@
       background-color: $colors--theme--background-negative-hover;
     }
   }
+
+  .file-upload__file-remove-button:hover {
+    background-color: $colors--theme--background-negative-hover;
+  }
 }
 
 .is-dark .is-error {

--- a/src/lib/components/FileUpload/FileUpload.scss
+++ b/src/lib/components/FileUpload/FileUpload.scss
@@ -1,4 +1,6 @@
+@use "sass:map";
 @import "vanilla-framework";
+
 @include vf-base;
 @include vf-p-buttons;
 
@@ -6,27 +8,22 @@
   padding-bottom: $spv--medium;
 }
 
-.file-upload {
-  @include vf-transition(border, fast);
-
-  border: 0.125rem solid $color-transparent;
-
-  &:hover {
-    border: 0.125rem solid $color-link;
-  }
-}
-
 .file-upload__button {
   @extend .p-button--link;
 
+  color: $colors--theme--text-default;
   text-align: left;
   width: 100%;
   padding: $spv--x-small $sph--small $sph--x-large $spv--small;
   margin-bottom: 0;
-  border: 0.0625rem dashed $color-mid-light;
+
+  background-color: $colors--theme--background-inputs;
+
+  border-bottom: 1.5px solid $colors--theme--border-high-contrast;
 
   &:hover {
-    border-color: $color-transparent;
+    text-decoration: none;
+    background-color: $colors--theme--background-hover;
   }
 }
 
@@ -35,14 +32,14 @@
   justify-content: space-between;
   align-items: center;
   padding-left: $sph--small;
-  background-color: $color-light;
+  background-color: $colors--theme--background-active;
   opacity: $inactive-text-opacity-amount;
   height: 2.25rem;
   width: 100%;
   margin-bottom: $spv--large;
 
   &.is-rejected {
-    background-color: $color-negative-background;
+    background-color: $colors--theme--background-negative-default;
   }
 }
 
@@ -52,15 +49,22 @@
 }
 
 .file-upload__file-remove-button {
-  margin-bottom: 0;
+  margin-bottom: 0 !important;
 }
 
 .is-error {
-  .file-upload {
-    border: 0.0625rem dashed $color-negative;
-  }
-
   .file-upload__button {
+    border-color: $colors--theme--border-negative;
     background-color: $color-negative-background;
+
+    &:hover {
+      background-color: $colors--theme--background-negative-hover;
+    }
+  }
+}
+
+.is-dark .is-error {
+  .file-upload__button {
+    background-color: map.get($colors-dark-theme--tinted-backgrounds, "negative", "default");
   }
 }

--- a/src/lib/components/FileUpload/FileUpload.scss
+++ b/src/lib/components/FileUpload/FileUpload.scss
@@ -1,6 +1,5 @@
 @use "sass:map";
 @import "vanilla-framework";
-
 @include vf-base;
 @include vf-p-buttons;
 
@@ -16,9 +15,7 @@
   width: 100%;
   padding: $spv--x-small $sph--small $sph--x-large $spv--small;
   margin-bottom: 0;
-
   background-color: $colors--theme--background-inputs;
-
   border-bottom: 1.5px solid $colors--theme--border-high-contrast;
 
   &:hover {

--- a/src/lib/components/FileUpload/FileUpload.stories.tsx
+++ b/src/lib/components/FileUpload/FileUpload.stories.tsx
@@ -13,10 +13,26 @@ export default meta;
 
 export const Example = {
   args: {
+    accept: {
+      "application/octet-stream": [
+        ".tgz",
+        ".tbz",
+        ".txz",
+        ".ddtgz",
+        ".ddtbz",
+        ".ddtxz",
+        ".ddtar",
+        ".ddbz2",
+        ".ddgz",
+        ".ddxz",
+        ".ddraw",
+      ],
+    },
     error: "",
     help: "Max file size is 2MB.",
     label: "Upload files",
-    maxFiles: 7,
+    maxFiles: 2,
     maxSize: 2000000,
+    minSize: 1000,
   },
 };

--- a/src/lib/components/FileUpload/FileUpload.stories.tsx
+++ b/src/lib/components/FileUpload/FileUpload.stories.tsx
@@ -1,10 +1,10 @@
 import { Meta } from "@storybook/react";
 
-import { FileUploadContainer } from "@/lib/components/FileUpload";
+import { FileUpload } from "@/lib/components/FileUpload";
 
-const meta: Meta<typeof FileUploadContainer> = {
+const meta: Meta<typeof FileUpload> = {
   title: "components/FileUpload",
-  component: FileUploadContainer,
+  component: FileUpload,
   tags: ["autodocs"],
   parameters: {},
 };

--- a/src/lib/components/FileUpload/FileUpload.test.tsx
+++ b/src/lib/components/FileUpload/FileUpload.test.tsx
@@ -95,7 +95,7 @@ describe("FileUpload", () => {
     expect(mockRemoveFile).toHaveBeenCalledWith(file);
   });
 
-  it("displays rejected files and reasons", () => {
+  it("displays rejected files", () => {
     const file = new File(["hello"], "hello.png", { type: "image/png" });
     const rejection = {
       file,
@@ -115,7 +115,7 @@ describe("FileUpload", () => {
     );
 
     expect(screen.getByText(file.name)).toBeInTheDocument();
-    expect(screen.getByText("This is an error")).toBeInTheDocument();
+    expect(screen.getByText(file.name)).toHaveClass("is-rejected");
   });
 
   it("hides the drop zone when the maximum number of files is met", () => {
@@ -148,7 +148,7 @@ describe("FileUpload", () => {
       />,
     );
 
-    expect(screen.getByText("This is an error.")).toBeInTheDocument();
+    expect(screen.getByText("This is an error")).toBeInTheDocument();
   });
 
   it("can display a label", () => {

--- a/src/lib/components/FileUpload/FileUpload.test.tsx
+++ b/src/lib/components/FileUpload/FileUpload.test.tsx
@@ -18,7 +18,7 @@ function createDataTransfer(files: File[]) {
 
 describe("FileUpload", () => {
   it("renders without crashing", () => {
-    render(<FileUpload />);
+    render(<FileUpload maxFiles={1} maxSize={2000} minSize={0} />);
 
     expect(
       screen.getByText("Drag and drop files here or click to upload"),
@@ -29,11 +29,14 @@ describe("FileUpload", () => {
     const mockOnFileUpload = vi.fn();
     render(
       <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
         onFileUpload={mockOnFileUpload}
         files={[]}
         rejectedFiles={[]}
-        removeFile={vi.fn()}
-        removeRejectedFile={vi.fn()}
+        onRemoveFile={vi.fn()}
+        onRemoveRejectedFile={vi.fn()}
       />,
     );
     const file = new File(["hello"], "hello.png", { type: "image/png" });
@@ -59,11 +62,14 @@ describe("FileUpload", () => {
 
     render(
       <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
         files={[file]}
         rejectedFiles={[]}
         onFileUpload={vi.fn()}
-        removeFile={vi.fn()}
-        removeRejectedFile={vi.fn()}
+        onRemoveFile={vi.fn()}
+        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
@@ -76,11 +82,14 @@ describe("FileUpload", () => {
 
     render(
       <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
         files={[file]}
-        removeFile={mockRemoveFile}
+        onRemoveFile={mockRemoveFile}
         rejectedFiles={[]}
         onFileUpload={vi.fn()}
-        removeRejectedFile={vi.fn()}
+        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
@@ -98,11 +107,14 @@ describe("FileUpload", () => {
 
     render(
       <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
         rejectedFiles={[rejection]}
         files={[]}
         onFileUpload={vi.fn()}
-        removeFile={vi.fn()}
-        removeRejectedFile={vi.fn()}
+        onRemoveFile={vi.fn()}
+        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
@@ -120,11 +132,14 @@ describe("FileUpload", () => {
 
     render(
       <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
         rejectedFiles={[rejection]}
-        removeRejectedFile={mockRemoveRejectedFile}
+        onRemoveRejectedFile={mockRemoveRejectedFile}
         files={[]}
         onFileUpload={vi.fn()}
-        removeFile={vi.fn()}
+        onRemoveFile={vi.fn()}
       />,
     );
 
@@ -138,12 +153,14 @@ describe("FileUpload", () => {
 
     render(
       <FileUpload
-        files={[file]}
         maxFiles={1}
+        maxSize={2000}
+        minSize={0}
+        files={[file]}
         rejectedFiles={[]}
         onFileUpload={vi.fn()}
-        removeFile={vi.fn()}
-        removeRejectedFile={vi.fn()}
+        onRemoveFile={vi.fn()}
+        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
@@ -153,26 +170,47 @@ describe("FileUpload", () => {
   });
 
   it("can display errors on the dropzone", () => {
-    render(<FileUpload error="This is an error" />);
+    render(
+      <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
+        error="This is an error"
+      />,
+    );
 
     expect(screen.getByText("This is an error")).toBeInTheDocument();
   });
 
   it("can display a label", () => {
-    render(<FileUpload label="Upload files" />);
+    render(
+      <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
+        label="Upload files"
+      />,
+    );
 
     expect(screen.getByLabelText("Upload files")).toBeInTheDocument();
   });
 
   it("can display help text", () => {
-    render(<FileUpload help="Some helpful text" />);
+    render(
+      <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
+        help="Some helpful text"
+      />,
+    );
 
     expect(screen.getByText("Some helpful text")).toBeInTheDocument();
   });
 
   it("works in uncontrolled mode with internal state management", async () => {
     // Render component without any state props - it should use internal state
-    render(<FileUpload maxFiles={2} />);
+    render(<FileUpload maxFiles={1} maxSize={2000} minSize={0} />);
 
     expect(
       screen.getByText("Drag and drop files here or click to upload"),

--- a/src/lib/components/FileUpload/FileUpload.test.tsx
+++ b/src/lib/components/FileUpload/FileUpload.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { FileUpload, FileUploadProps } from "@/lib";
+import { FileUpload } from "@/lib";
 
 function createDataTransfer(files: File[]) {
   return {
@@ -17,12 +17,8 @@ function createDataTransfer(files: File[]) {
 }
 
 describe("FileUpload", () => {
-  const renderFileUpload = (options?: Partial<FileUploadProps>) => {
-    return render(<FileUpload {...options} />);
-  };
-
   it("renders without crashing", () => {
-    renderFileUpload();
+    render(<FileUpload />);
 
     expect(
       screen.getByText("Drag and drop files here or click to upload"),
@@ -31,13 +27,15 @@ describe("FileUpload", () => {
 
   it("calls onFileUpload when files are dropped", async () => {
     const mockOnFileUpload = vi.fn();
-    renderFileUpload({
-      onFileUpload: mockOnFileUpload,
-      files: [],
-      rejectedFiles: [],
-      removeFile: vi.fn(),
-      removeRejectedFile: vi.fn(),
-    });
+    render(
+      <FileUpload
+        onFileUpload={mockOnFileUpload}
+        files={[]}
+        rejectedFiles={[]}
+        removeFile={vi.fn()}
+        removeRejectedFile={vi.fn()}
+      />,
+    );
     const file = new File(["hello"], "hello.png", { type: "image/png" });
     const dropEvent = await fireEvent.drop(
       screen.getByText("Drag and drop files here or click to upload"),
@@ -59,13 +57,15 @@ describe("FileUpload", () => {
   it("displays accepted files", () => {
     const file = new File(["hello"], "hello.png", { type: "image/png" });
 
-    renderFileUpload({
-      files: [file],
-      rejectedFiles: [],
-      onFileUpload: vi.fn(),
-      removeFile: vi.fn(),
-      removeRejectedFile: vi.fn(),
-    });
+    render(
+      <FileUpload
+        files={[file]}
+        rejectedFiles={[]}
+        onFileUpload={vi.fn()}
+        removeFile={vi.fn()}
+        removeRejectedFile={vi.fn()}
+      />,
+    );
 
     expect(screen.getByText(file.name)).toBeInTheDocument();
   });
@@ -74,13 +74,15 @@ describe("FileUpload", () => {
     const file = new File(["hello"], "hello.png", { type: "image/png" });
     const mockRemoveFile = vi.fn();
 
-    renderFileUpload({
-      files: [file],
-      removeFile: mockRemoveFile,
-      rejectedFiles: [],
-      onFileUpload: vi.fn(),
-      removeRejectedFile: vi.fn(),
-    });
+    render(
+      <FileUpload
+        files={[file]}
+        removeFile={mockRemoveFile}
+        rejectedFiles={[]}
+        onFileUpload={vi.fn()}
+        removeRejectedFile={vi.fn()}
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
 
@@ -94,13 +96,15 @@ describe("FileUpload", () => {
       errors: [{ code: "an-error-code", message: "This is an error" }],
     };
 
-    renderFileUpload({
-      rejectedFiles: [rejection],
-      files: [],
-      onFileUpload: vi.fn(),
-      removeFile: vi.fn(),
-      removeRejectedFile: vi.fn(),
-    });
+    render(
+      <FileUpload
+        rejectedFiles={[rejection]}
+        files={[]}
+        onFileUpload={vi.fn()}
+        removeFile={vi.fn()}
+        removeRejectedFile={vi.fn()}
+      />,
+    );
 
     expect(screen.getByText(file.name)).toBeInTheDocument();
     expect(screen.getByText("This is an error")).toBeInTheDocument();
@@ -114,13 +118,15 @@ describe("FileUpload", () => {
     };
     const mockRemoveRejectedFile = vi.fn();
 
-    renderFileUpload({
-      rejectedFiles: [rejection],
-      removeRejectedFile: mockRemoveRejectedFile,
-      files: [],
-      onFileUpload: vi.fn(),
-      removeFile: vi.fn(),
-    });
+    render(
+      <FileUpload
+        rejectedFiles={[rejection]}
+        removeRejectedFile={mockRemoveRejectedFile}
+        files={[]}
+        onFileUpload={vi.fn()}
+        removeFile={vi.fn()}
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
 
@@ -130,14 +136,16 @@ describe("FileUpload", () => {
   it("hides the drop zone when the maximum number of files is met", () => {
     const file = new File(["hello"], "hello.png", { type: "image/png" });
 
-    renderFileUpload({
-      files: [file],
-      maxFiles: 1,
-      rejectedFiles: [],
-      onFileUpload: vi.fn(),
-      removeFile: vi.fn(),
-      removeRejectedFile: vi.fn(),
-    });
+    render(
+      <FileUpload
+        files={[file]}
+        maxFiles={1}
+        rejectedFiles={[]}
+        onFileUpload={vi.fn()}
+        removeFile={vi.fn()}
+        removeRejectedFile={vi.fn()}
+      />,
+    );
 
     expect(
       screen.queryByText("Drag and drop files here or click to upload"),
@@ -145,26 +153,26 @@ describe("FileUpload", () => {
   });
 
   it("can display errors on the dropzone", () => {
-    renderFileUpload({ error: "This is an error" });
+    render(<FileUpload error="This is an error" />);
 
     expect(screen.getByText("This is an error")).toBeInTheDocument();
   });
 
   it("can display a label", () => {
-    renderFileUpload({ label: "Upload files" });
+    render(<FileUpload label="Upload files" />);
 
     expect(screen.getByLabelText("Upload files")).toBeInTheDocument();
   });
 
   it("can display help text", () => {
-    renderFileUpload({ help: "Some helpful text" });
+    render(<FileUpload help="Some helpful text" />);
 
     expect(screen.getByText("Some helpful text")).toBeInTheDocument();
   });
 
   it("works in uncontrolled mode with internal state management", async () => {
     // Render component without any state props - it should use internal state
-    renderFileUpload({ maxFiles: 2 });
+    render(<FileUpload maxFiles={2} />);
 
     expect(
       screen.getByText("Drag and drop files here or click to upload"),

--- a/src/lib/components/FileUpload/FileUpload.test.tsx
+++ b/src/lib/components/FileUpload/FileUpload.test.tsx
@@ -2,8 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { FileUpload, FileUploadProps } from "./FileUpload";
-beforeEach(() => {});
+import { FileUpload, FileUploadProps } from "@/lib";
 
 function createDataTransfer(files: File[]) {
   return {
@@ -17,122 +16,183 @@ function createDataTransfer(files: File[]) {
   };
 }
 
-const renderFileUpload = (options?: Partial<FileUploadProps>) => {
-  return render(
-    <FileUpload
-      files={[]}
-      onFileUpload={vi.fn()}
-      rejectedFiles={[]}
-      removeFile={vi.fn()}
-      removeRejectedFile={vi.fn()}
-      {...options}
-    />,
-  );
-};
-
-it("renders without crashing", () => {
-  renderFileUpload();
-
-  expect(
-    screen.getByText("Drag and drop files here or click to upload"),
-  ).toBeInTheDocument();
-});
-
-it("calls onFileUpload when files are dropped", async () => {
-  const mockOnFileUpload = vi.fn();
-  renderFileUpload({ onFileUpload: mockOnFileUpload });
-  const file = new File(["hello"], "hello.png", { type: "image/png" });
-  const dropEvent = await fireEvent.drop(
-    screen.getByText("Drag and drop files here or click to upload"),
-    {
-      dataTransfer: createDataTransfer([file]),
-    },
-  );
-
-  expect(dropEvent).toMatchInlineSnapshot("false");
-  await waitFor(() =>
-    expect(mockOnFileUpload).toHaveBeenCalledWith(
-      [file],
-      expect.anything(),
-      expect.anything(),
-    ),
-  );
-});
-
-it("displays accepted files", () => {
-  const file = new File(["hello"], "hello.png", { type: "image/png" });
-
-  renderFileUpload({ files: [file] });
-
-  expect(screen.getByText(file.name)).toBeInTheDocument();
-});
-
-it("calls removeFile when the 'remove' button is clicked", async () => {
-  const file = new File(["hello"], "hello.png", { type: "image/png" });
-  const mockRemoveFile = vi.fn();
-
-  renderFileUpload({ files: [file], removeFile: mockRemoveFile });
-
-  await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
-
-  expect(mockRemoveFile).toHaveBeenCalledWith(file);
-});
-
-it("displays rejected files and reasons", () => {
-  const file = new File(["hello"], "hello.png", { type: "image/png" });
-  const rejection = {
-    file,
-    errors: [{ code: "an-error-code", message: "This is an error" }],
+describe("FileUpload", () => {
+  const renderFileUpload = (options?: Partial<FileUploadProps>) => {
+    return render(<FileUpload {...options} />);
   };
 
-  renderFileUpload({ rejectedFiles: [rejection] });
+  it("renders without crashing", () => {
+    renderFileUpload();
 
-  expect(screen.getByText(file.name)).toBeInTheDocument();
-  expect(screen.getByText("This is an error")).toBeInTheDocument();
-});
-
-it("calls removeRejectedFile when the 'remove' button is clicked", async () => {
-  const file = new File(["hello"], "hello.png", { type: "image/png" });
-  const rejection = {
-    file,
-    errors: [{ code: "an-error-code", message: "This is an error" }],
-  };
-  const mockRemoveRejectedFile = vi.fn();
-
-  renderFileUpload({
-    rejectedFiles: [rejection],
-    removeRejectedFile: mockRemoveRejectedFile,
+    expect(
+      screen.getByText("Drag and drop files here or click to upload"),
+    ).toBeInTheDocument();
   });
 
-  await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
+  it("calls onFileUpload when files are dropped", async () => {
+    const mockOnFileUpload = vi.fn();
+    renderFileUpload({
+      onFileUpload: mockOnFileUpload,
+      files: [],
+      rejectedFiles: [],
+      removeFile: vi.fn(),
+      removeRejectedFile: vi.fn(),
+    });
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    const dropEvent = await fireEvent.drop(
+      screen.getByText("Drag and drop files here or click to upload"),
+      {
+        dataTransfer: createDataTransfer([file]),
+      },
+    );
 
-  expect(mockRemoveRejectedFile).toHaveBeenCalledWith(rejection);
-});
+    expect(dropEvent).toMatchInlineSnapshot("false");
+    await waitFor(() =>
+      expect(mockOnFileUpload).toHaveBeenCalledWith(
+        [file],
+        expect.anything(),
+        expect.anything(),
+      ),
+    );
+  });
 
-it("hides the drop zone when the maximum number of files is met", () => {
-  const file = new File(["hello"], "hello.png", { type: "image/png" });
+  it("displays accepted files", () => {
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
 
-  renderFileUpload({ files: [file], maxFiles: 1 });
+    renderFileUpload({
+      files: [file],
+      rejectedFiles: [],
+      onFileUpload: vi.fn(),
+      removeFile: vi.fn(),
+      removeRejectedFile: vi.fn(),
+    });
 
-  expect(
-    screen.queryByText("Drag and drop files here or click to upload"),
-  ).not.toBeInTheDocument();
-});
+    expect(screen.getByText(file.name)).toBeInTheDocument();
+  });
 
-it("can display errors on the dropzone", () => {
-  renderFileUpload({ error: "This is an error" });
+  it("calls removeFile when the 'remove' button is clicked", async () => {
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    const mockRemoveFile = vi.fn();
 
-  expect(screen.getByText("This is an error")).toBeInTheDocument();
-});
+    renderFileUpload({
+      files: [file],
+      removeFile: mockRemoveFile,
+      rejectedFiles: [],
+      onFileUpload: vi.fn(),
+      removeRejectedFile: vi.fn(),
+    });
 
-it("can display a label", () => {
-  renderFileUpload({ label: "Upload files" });
+    await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
 
-  expect(screen.getByLabelText("Upload files")).toBeInTheDocument();
-});
+    expect(mockRemoveFile).toHaveBeenCalledWith(file);
+  });
 
-it("can display help text", () => {
-  renderFileUpload({ help: "Some helpful text" });
+  it("displays rejected files and reasons", () => {
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    const rejection = {
+      file,
+      errors: [{ code: "an-error-code", message: "This is an error" }],
+    };
 
-  expect(screen.getByText("Some helpful text")).toBeInTheDocument();
+    renderFileUpload({
+      rejectedFiles: [rejection],
+      files: [],
+      onFileUpload: vi.fn(),
+      removeFile: vi.fn(),
+      removeRejectedFile: vi.fn(),
+    });
+
+    expect(screen.getByText(file.name)).toBeInTheDocument();
+    expect(screen.getByText("This is an error")).toBeInTheDocument();
+  });
+
+  it("calls removeRejectedFile when the 'remove' button is clicked", async () => {
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    const rejection = {
+      file,
+      errors: [{ code: "an-error-code", message: "This is an error" }],
+    };
+    const mockRemoveRejectedFile = vi.fn();
+
+    renderFileUpload({
+      rejectedFiles: [rejection],
+      removeRejectedFile: mockRemoveRejectedFile,
+      files: [],
+      onFileUpload: vi.fn(),
+      removeFile: vi.fn(),
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
+
+    expect(mockRemoveRejectedFile).toHaveBeenCalledWith(rejection);
+  });
+
+  it("hides the drop zone when the maximum number of files is met", () => {
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+
+    renderFileUpload({
+      files: [file],
+      maxFiles: 1,
+      rejectedFiles: [],
+      onFileUpload: vi.fn(),
+      removeFile: vi.fn(),
+      removeRejectedFile: vi.fn(),
+    });
+
+    expect(
+      screen.queryByText("Drag and drop files here or click to upload"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("can display errors on the dropzone", () => {
+    renderFileUpload({ error: "This is an error" });
+
+    expect(screen.getByText("This is an error")).toBeInTheDocument();
+  });
+
+  it("can display a label", () => {
+    renderFileUpload({ label: "Upload files" });
+
+    expect(screen.getByLabelText("Upload files")).toBeInTheDocument();
+  });
+
+  it("can display help text", () => {
+    renderFileUpload({ help: "Some helpful text" });
+
+    expect(screen.getByText("Some helpful text")).toBeInTheDocument();
+  });
+
+  it("works in uncontrolled mode with internal state management", async () => {
+    // Render component without any state props - it should use internal state
+    renderFileUpload({ maxFiles: 2 });
+
+    expect(
+      screen.getByText("Drag and drop files here or click to upload"),
+    ).toBeInTheDocument();
+
+    // Drop a file
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    await fireEvent.drop(
+      screen.getByText("Drag and drop files here or click to upload"),
+      {
+        dataTransfer: createDataTransfer([file]),
+      },
+    );
+
+    // The file should appear in the list (managed by internal state)
+    await waitFor(() => {
+      expect(screen.getByText(file.name)).toBeInTheDocument();
+    });
+
+    // Remove button should be present
+    expect(screen.getByRole("button", { name: /Remove/i })).toBeInTheDocument();
+
+    // Click remove button
+    await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
+
+    // File should be removed from the list
+    await waitFor(() => {
+      expect(screen.queryByText(file.name)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/lib/components/FileUpload/FileUpload.test.tsx
+++ b/src/lib/components/FileUpload/FileUpload.test.tsx
@@ -18,7 +18,7 @@ function createDataTransfer(files: File[]) {
 
 describe("FileUpload", () => {
   it("renders without crashing", () => {
-    render(<FileUpload maxFiles={1} maxSize={2000} minSize={0} />);
+    render(<FileUpload />);
 
     expect(
       screen.getByText("Drag and drop files here or click to upload"),
@@ -36,7 +36,6 @@ describe("FileUpload", () => {
         files={[]}
         rejectedFiles={[]}
         onRemoveFile={vi.fn()}
-        onRemoveRejectedFile={vi.fn()}
       />,
     );
     const file = new File(["hello"], "hello.png", { type: "image/png" });
@@ -69,7 +68,6 @@ describe("FileUpload", () => {
         rejectedFiles={[]}
         onFileUpload={vi.fn()}
         onRemoveFile={vi.fn()}
-        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
@@ -89,7 +87,6 @@ describe("FileUpload", () => {
         onRemoveFile={mockRemoveFile}
         rejectedFiles={[]}
         onFileUpload={vi.fn()}
-        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
@@ -114,38 +111,11 @@ describe("FileUpload", () => {
         files={[]}
         onFileUpload={vi.fn()}
         onRemoveFile={vi.fn()}
-        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
     expect(screen.getByText(file.name)).toBeInTheDocument();
     expect(screen.getByText("This is an error")).toBeInTheDocument();
-  });
-
-  it("calls removeRejectedFile when the 'remove' button is clicked", async () => {
-    const file = new File(["hello"], "hello.png", { type: "image/png" });
-    const rejection = {
-      file,
-      errors: [{ code: "an-error-code", message: "This is an error" }],
-    };
-    const mockRemoveRejectedFile = vi.fn();
-
-    render(
-      <FileUpload
-        maxFiles={1}
-        maxSize={2000}
-        minSize={0}
-        rejectedFiles={[rejection]}
-        onRemoveRejectedFile={mockRemoveRejectedFile}
-        files={[]}
-        onFileUpload={vi.fn()}
-        onRemoveFile={vi.fn()}
-      />,
-    );
-
-    await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
-
-    expect(mockRemoveRejectedFile).toHaveBeenCalledWith(rejection);
   });
 
   it("hides the drop zone when the maximum number of files is met", () => {
@@ -160,7 +130,6 @@ describe("FileUpload", () => {
         rejectedFiles={[]}
         onFileUpload={vi.fn()}
         onRemoveFile={vi.fn()}
-        onRemoveRejectedFile={vi.fn()}
       />,
     );
 
@@ -179,7 +148,7 @@ describe("FileUpload", () => {
       />,
     );
 
-    expect(screen.getByText("This is an error")).toBeInTheDocument();
+    expect(screen.getByText("This is an error.")).toBeInTheDocument();
   });
 
   it("can display a label", () => {
@@ -240,5 +209,51 @@ describe("FileUpload", () => {
     await waitFor(() => {
       expect(screen.queryByText(file.name)).not.toBeInTheDocument();
     });
+  });
+
+  it("calls onRemove when removing accepted files", async () => {
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    const mockOnRemove = vi.fn();
+
+    render(
+      <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
+        files={[file]}
+        onRemoveFile={mockOnRemove}
+        rejectedFiles={[]}
+        onFileUpload={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
+
+    expect(mockOnRemove).toHaveBeenCalledWith(file);
+  });
+
+  it("calls onRemove when removing rejected files", async () => {
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    const rejection = {
+      file,
+      errors: [{ code: "file-too-large", message: "File is too large" }],
+    };
+    const mockOnRemove = vi.fn();
+
+    render(
+      <FileUpload
+        maxFiles={1}
+        maxSize={2000}
+        minSize={0}
+        rejectedFiles={[rejection]}
+        onRemoveFile={mockOnRemove}
+        files={[]}
+        onFileUpload={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Remove/i }));
+
+    expect(mockOnRemove).toHaveBeenCalledWith(rejection);
   });
 });

--- a/src/lib/components/FileUpload/FileUpload.tsx
+++ b/src/lib/components/FileUpload/FileUpload.tsx
@@ -108,14 +108,6 @@ export const FileUpload = ({
                     <Icon name="close">Remove file</Icon>
                   </Button>
                 </div>
-                {rejection.errors.map((error) => (
-                  <p
-                    className="p-form-validation__message"
-                    key={`${rejection.file.name}-${error.code}`}
-                  >
-                    {error.message}
-                  </p>
-                ))}
               </span>
             ))}
           {files &&
@@ -140,7 +132,7 @@ export const FileUpload = ({
         {error ? (
           <p className="p-form-validation__message">
             <strong>Error: </strong>
-            {error}.
+            {error}
           </p>
         ) : null}
       </div>

--- a/src/lib/components/FileUpload/FileUpload.tsx
+++ b/src/lib/components/FileUpload/FileUpload.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useId } from "react";
+import { ReactElement, ReactNode, useId } from "react";
 
 import { Button, Icon, Label } from "@canonical/react-components";
 import classNames from "classnames";
@@ -14,31 +14,41 @@ export type FileUploadFile = File & { percentUploaded?: number };
 export interface FileUploadProps {
   accept?: DropzoneOptions["accept"];
   error?: ReactNode;
-  files: FileUploadFile[];
+  files?: FileUploadFile[];
   help?: string;
   label?: string;
   maxFiles?: number;
   maxSize?: number;
-  onFileUpload: NonNullable<DropzoneOptions["onDrop"]>;
-  rejectedFiles: FileRejection[];
-  removeFile: (file: FileUploadFile) => void;
-  removeRejectedFile: (fileRejection: FileRejection) => void;
+  onFileUpload?: NonNullable<DropzoneOptions["onDrop"]>;
+  rejectedFiles?: FileRejection[];
+  removeFile?: (file: FileUploadFile) => void;
+  removeRejectedFile?: (fileRejection: FileRejection) => void;
 }
 
-export const FileUpload: React.FC<FileUploadProps> = ({
+export const FileUpload = ({
   accept,
   error,
-  files,
+  files: filesProp,
   help,
   label,
   maxFiles,
   maxSize,
-  onFileUpload,
-  rejectedFiles,
-  removeFile,
-  removeRejectedFile,
-}: FileUploadProps) => {
-  const { getRootProps } = useDropzone({
+  onFileUpload: onFileUploadProp,
+  rejectedFiles: rejectedFilesProp,
+  removeFile: removeFileProp,
+  removeRejectedFile: removeRejectedFileProp,
+}: FileUploadProps): ReactElement => {
+  // Use internal state management if props are not provided (uncontrolled mode)
+  const internalState = useFileUpload();
+
+  // Use provided props or fall back to internal state
+  const files = filesProp ?? internalState.acceptedFiles;
+  const rejectedFiles = rejectedFilesProp ?? internalState.fileRejections;
+  const onFileUpload = onFileUploadProp ?? internalState.onFileUpload;
+  const removeFile = removeFileProp ?? internalState.removeFile;
+  const removeRejectedFile = removeRejectedFileProp ?? internalState.removeRejectedFile;
+
+  const { getRootProps, getInputProps } = useDropzone({
     accept,
     maxFiles,
     maxSize,
@@ -64,6 +74,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
               className="file-upload"
               data-testid="file-upload"
             >
+              <input {...getInputProps()} />
               <button className="file-upload__button" type="button">
                 Drag and drop files here or click to upload
               </button>
@@ -125,38 +136,3 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   );
 };
 
-export const FileUploadContainer = ({
-  accept,
-  error,
-  help,
-  label,
-  maxFiles,
-  maxSize,
-}: Pick<
-  FileUploadProps,
-  "accept" | "error" | "help" | "label" | "maxFiles" | "maxSize"
->) => {
-  const {
-    acceptedFiles,
-    fileRejections,
-    onFileUpload,
-    removeFile,
-    removeRejectedFile,
-  } = useFileUpload();
-
-  return (
-    <FileUpload
-      accept={accept}
-      error={error}
-      files={acceptedFiles}
-      rejectedFiles={fileRejections}
-      help={help}
-      label={label}
-      maxFiles={maxFiles}
-      maxSize={maxSize}
-      onFileUpload={onFileUpload}
-      removeFile={removeFile}
-      removeRejectedFile={removeRejectedFile}
-    />
-  );
-};

--- a/src/lib/components/FileUpload/FileUpload.tsx
+++ b/src/lib/components/FileUpload/FileUpload.tsx
@@ -19,10 +19,11 @@ export interface FileUploadProps {
   label?: string;
   maxFiles?: number;
   maxSize?: number;
+  minSize?: number;
   onFileUpload?: NonNullable<DropzoneOptions["onDrop"]>;
   rejectedFiles?: FileRejection[];
-  removeFile?: (file: FileUploadFile) => void;
-  removeRejectedFile?: (fileRejection: FileRejection) => void;
+  onRemoveFile?: (file: FileUploadFile) => void;
+  onRemoveRejectedFile?: (fileRejection: FileRejection) => void;
 }
 
 export const FileUpload = ({
@@ -33,10 +34,11 @@ export const FileUpload = ({
   label,
   maxFiles,
   maxSize,
+  minSize,
   onFileUpload: onFileUploadProp,
+  onRemoveFile: removeFileProp,
+  onRemoveRejectedFile: removeRejectedFileProp,
   rejectedFiles: rejectedFilesProp,
-  removeFile: removeFileProp,
-  removeRejectedFile: removeRejectedFileProp,
 }: FileUploadProps): ReactElement => {
   // Use internal state management if props are not provided (uncontrolled mode)
   const internalState = useFileUpload();
@@ -52,6 +54,7 @@ export const FileUpload = ({
     accept,
     maxFiles,
     maxSize,
+    minSize,
     onDrop: onFileUpload,
   });
 
@@ -80,12 +83,6 @@ export const FileUpload = ({
               </button>
             </div>
           </div>
-        ) : null}
-        {error ? (
-          <p className="p-form-validation__message">
-            <strong>Error: </strong>
-            {error}
-          </p>
         ) : null}
         <div className="file-upload__files-list">
           {rejectedFiles &&
@@ -131,8 +128,13 @@ export const FileUpload = ({
               </div>
             ))}
         </div>
+        {error ? (
+          <p className="p-form-validation__message">
+            <strong>Error: </strong>
+            {error}.
+          </p>
+        ) : null}
       </div>
     </div>
   );
 };
-

--- a/src/lib/components/FileUpload/FileUpload.tsx
+++ b/src/lib/components/FileUpload/FileUpload.tsx
@@ -21,14 +21,71 @@ export interface FileUploadProps {
   maxSize?: number;
   minSize?: number;
   onFileUpload?: NonNullable<DropzoneOptions["onDrop"]>;
-  rejectedFiles?: FileRejection[];
   onRemoveFile?: (item: FileUploadFile | FileRejection) => void;
+  rejectedFiles?: FileRejection[];
 }
 
+/**
+ * FileUpload - A controllable file upload input field with internal validation
+ *
+ * A file upload input field supporting both controlled and uncontrolled modes.
+ * Can be used standalone for simple file uploads or with external state management
+ * (React state or Formik) for complex forms. Built on React Dropzone with support
+ * for file validation and upload progress tracking.
+ *
+ * @param {Object} props - Component props
+ * @param {DropzoneOptions["accept"]} [props.accept] - Allowed file types
+ * @param {ReactNode} [props.error] - Externally stored error message to display
+ * @param {FileUploadFile[]} [props.files] - Externally stored array of accepted files
+ * @param {string} [props.help] - Help text displayed below the label
+ * @param {string} [props.label] - Field label text
+ * @param {number} [props.maxFiles] - Maximum number of files allowed
+ * @param {number} [props.maxSize] - Maximum file size in bytes
+ * @param {number} [props.minSize] - Minimum file size in bytes
+ * @param {NonNullable<DropzoneOptions["onDrop"]>} [props.onFileUpload] - Callback triggered when files are dropped or selected
+ * @param {(item: FileUploadFile | FileRejection) => void} [props.onRemoveFile] - Callback triggered when a file is removed
+ * @param {FileRejection[]} [props.rejectedFiles] - Externally stored array of rejected files with error details
+ *
+ * @returns {ReactElement} - The rendered file upload field component
+ *
+ * @example
+ * // Simple usage with React state
+ * const [files, setFiles] = useState();
+ * const [rejected, setRejected] = useState();
+ * <FileUpload
+ *   accept={{"image": [".jpeg", ".png"]}}
+ *   files={files}
+ *   rejectedFiles={rejected}
+ *   maxFiles={1}
+ *   maxSize={20000}
+ *   label="Profile Picture"
+ *   onFileUpload={(accepted) => setFiles(accepted)}
+ *   onRemoveFile={() => setFiles([])}
+ * />
+ *
+ * @example
+ * // With Formik - simplified usage
+ * const formik = useFormik();
+ * <FileUpload
+ *   accept={{"image": [".jpeg", ".png"]}}
+ *   files={formik.values.file ? [formik.values.file] : []}
+ *   error={formik.touched.file && formik.errors.file}
+ *   maxFiles={1}
+ *   maxSize={20000}
+ *   label="Profile Picture"
+ *   onFileUpload={(accepted) => {
+ *     if (accepted.length) {
+ *       formik.setFieldValue("file", accepted[0]);
+ *       formik.setFieldError("file", undefined);
+ *     }
+ *   }}
+ *   onRemoveFile={() => formik.setFieldValue("file", null)}
+ * />
+ */
 export const FileUpload = ({
   accept,
   error,
-  files: filesProp,
+  files,
   help,
   label,
   maxFiles,
@@ -36,14 +93,14 @@ export const FileUpload = ({
   minSize,
   onFileUpload,
   onRemoveFile,
-  rejectedFiles: rejectedFilesProp,
+  rejectedFiles,
 }: FileUploadProps): ReactElement => {
   // Use internal state management if props are not provided (uncontrolled mode)
   const internalState = useFileUpload();
 
   // Use provided props or fall back to internal state
-  const files = filesProp ?? internalState.acceptedFiles;
-  const rejectedFiles = rejectedFilesProp ?? internalState.fileRejections;
+  const acceptedFileList = files ?? internalState.acceptedFiles;
+  const rejectedFileList = rejectedFiles ?? internalState.fileRejections;
   const onDrop = onFileUpload ?? internalState.onFileUpload;
 
   // Unified remove handler with backward compatibility
@@ -78,7 +135,8 @@ export const FileUpload = ({
       {label && <Label id={labelId}>{label}</Label>}
       {help && <p className="p-form-help-text">{help}</p>}
       <div className="p-form__control">
-        {!maxFiles || files.length + rejectedFiles.length < maxFiles ? (
+        {!maxFiles ||
+        acceptedFileList.length + rejectedFileList.length < maxFiles ? (
           <div className="file-upload__wrapper">
             <div
               {...getRootProps()}
@@ -94,8 +152,8 @@ export const FileUpload = ({
           </div>
         ) : null}
         <div className="file-upload__files-list">
-          {rejectedFiles &&
-            rejectedFiles.map((rejection) => (
+          {rejectedFileList &&
+            rejectedFileList.map((rejection) => (
               <span className="is-error" key={rejection.file.name}>
                 <div className="file-upload__file is-rejected">
                   {rejection.file.name}
@@ -110,8 +168,8 @@ export const FileUpload = ({
                 </div>
               </span>
             ))}
-          {files &&
-            files.map((file) => (
+          {acceptedFileList &&
+            acceptedFileList.map((file) => (
               <div className="file-upload__file" key={file.name}>
                 {file.name}
                 {file.percentUploaded !== undefined ? (

--- a/src/lib/components/FileUpload/FileUpload.tsx
+++ b/src/lib/components/FileUpload/FileUpload.tsx
@@ -22,8 +22,7 @@ export interface FileUploadProps {
   minSize?: number;
   onFileUpload?: NonNullable<DropzoneOptions["onDrop"]>;
   rejectedFiles?: FileRejection[];
-  onRemoveFile?: (file: FileUploadFile) => void;
-  onRemoveRejectedFile?: (fileRejection: FileRejection) => void;
+  onRemoveFile?: (item: FileUploadFile | FileRejection) => void;
 }
 
 export const FileUpload = ({
@@ -35,9 +34,8 @@ export const FileUpload = ({
   maxFiles,
   maxSize,
   minSize,
-  onFileUpload: onFileUploadProp,
-  onRemoveFile: removeFileProp,
-  onRemoveRejectedFile: removeRejectedFileProp,
+  onFileUpload,
+  onRemoveFile,
   rejectedFiles: rejectedFilesProp,
 }: FileUploadProps): ReactElement => {
   // Use internal state management if props are not provided (uncontrolled mode)
@@ -46,16 +44,27 @@ export const FileUpload = ({
   // Use provided props or fall back to internal state
   const files = filesProp ?? internalState.acceptedFiles;
   const rejectedFiles = rejectedFilesProp ?? internalState.fileRejections;
-  const onFileUpload = onFileUploadProp ?? internalState.onFileUpload;
-  const removeFile = removeFileProp ?? internalState.removeFile;
-  const removeRejectedFile = removeRejectedFileProp ?? internalState.removeRejectedFile;
+  const onDrop = onFileUpload ?? internalState.onFileUpload;
+
+  // Unified remove handler with backward compatibility
+  const handleRemove = (item: FileUploadFile | FileRejection) => {
+    if (onRemoveFile) {
+      onRemoveFile(item);
+    } else if ("file" in item && "errors" in item) {
+      // It's a FileRejection
+      internalState.removeRejectedFile(item);
+    } else {
+      // It's a FileUploadFile
+      internalState.removeFile(item as FileUploadFile);
+    }
+  };
 
   const { getRootProps, getInputProps } = useDropzone({
     accept,
     maxFiles,
     maxSize,
     minSize,
-    onDrop: onFileUpload,
+    onDrop,
   });
 
   const labelId = useId();
@@ -69,7 +78,7 @@ export const FileUpload = ({
       {label && <Label id={labelId}>{label}</Label>}
       {help && <p className="p-form-help-text">{help}</p>}
       <div className="p-form__control">
-        {!maxFiles || files.length < maxFiles ? (
+        {!maxFiles || files.length + rejectedFiles.length < maxFiles ? (
           <div className="file-upload__wrapper">
             <div
               {...getRootProps()}
@@ -93,7 +102,7 @@ export const FileUpload = ({
                   <Button
                     appearance="base"
                     className="file-upload__file-remove-button"
-                    onClick={() => removeRejectedFile(rejection)}
+                    onClick={() => handleRemove(rejection)}
                     type="button"
                   >
                     <Icon name="close">Remove file</Icon>
@@ -119,7 +128,7 @@ export const FileUpload = ({
                   <Button
                     appearance="base"
                     className="file-upload__file-remove-button"
-                    onClick={() => removeFile(file)}
+                    onClick={() => handleRemove(file)}
                     type="button"
                   >
                     <Icon name="close">Remove file</Icon>


### PR DESCRIPTION
## Done

- Removed the FileUploadContainer
- Incorporated the FileUploadContainer state management into FileUpload
- Made state management optionally internal
- Fixed the storybook
- Fixed tests, introduced an internal state test

## QA steps

- [x]  Ensure the component is displayed correctly across all breakpoints
- [x] Ensure dragging and dropping a file adds it to the upload list
- [x] Ensure clicking the drop zone opens the file explorer
- [x] Ensure selecting file(s) in the explorer add them to the upload list
- [x] Ensure the "Remove file" button removes the files
- [x] Try uploading files that pass and fail validation (size, extension)
- [x] Verify correct error messages are shown
- [x] Ensure you cannot upload files more than allowed (maxFiles)
- [x] Open maas-ui
- [x] Checkout to abuyukyi/feat-introduce-custom-image-upload-MAASENG-5719
- [x] Link the @canonical/maas-react-components to maas-ui
- [x] Navigate to /images
- [x] Open the "Upload custom image" form
- [ ] Verify all the functionalities you tested in the Storybook also work
- [ ] Ensure invalid uploads prevent form submission
- [ ] Verify when there is an invalid upload, changing another field does not remove the error
- [x] Ensure the styling is appropriate for light and dark modes

## Fixes

Fixes: 

https://warthogs.atlassian.net/browse/MAASENG-5932