### PR TITLE
fix(GenericTable): TableAllCheckbox partial selection state over selectable rows rather than all rows as some may be disabled but selected

### DIFF
--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -449,6 +449,59 @@ export const ConditionallySelectable: Story = {
   },
 };
 
+export const PreSelected: Story = {
+  name: "Selectable (Pre-selected)",
+  render: (args) => {
+    const existingMemberIds = new Set(
+      args.data.slice(0, 2).map((row: Machine) => row.id),
+    );
+
+    const [rowSelection, setRowSelection] = useState<RowSelectionState>(
+      Object.fromEntries(
+        [...existingMemberIds].map((id) => [String(id), true]),
+      ),
+    );
+
+    return (
+      <div style={{ width: "100%" }}>
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "space-between",
+            marginBottom: "1rem",
+          }}
+        >
+          <h5>Selected machines: {Object.keys(rowSelection).length}</h5>
+          <div className="p-button-group">
+            <Button
+              appearance="negative"
+              disabled={Object.keys(rowSelection).length === 0}
+            >
+              Delete
+            </Button>
+          </div>
+        </div>
+        <GenericTable
+          {...args}
+          selection={{
+            rowSelection,
+            setRowSelection,
+            filterSelectable: (row: Row<Machine>) =>
+              !existingMemberIds.has(row.original.id),
+            disabledSelectionTooltip: () =>
+              "This user is already a member of the group.",
+            rowSelectionLabelKey: "fqdn",
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    columns: machineColumns.filter((column) => column.id !== "actions"),
+  },
+};
+
 export const Grouped: Story = {
   args: {
     columns: [

--- a/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
+++ b/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
@@ -23,10 +23,14 @@ const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
     .getCoreRowModel()
     .rows.filter((row) => row.getCanSelect());
 
+  const selectedSelectableRows = table
+    .getSelectedRowModel()
+    .rows.filter((row) => row.getCanSelect());
+
   let checked: boolean | "false" | "mixed" | "true" | undefined;
-  if (table.getSelectedRowModel().rows.length === 0) {
+  if (selectedSelectableRows.length === 0) {
     checked = "false";
-  } else if (table.getSelectedRowModel().rows.length < selectableRows.length) {
+  } else if (selectedSelectableRows.length < selectableRows.length) {
     checked = "mixed";
   } else {
     checked = "true";


### PR DESCRIPTION
## Done

- Determine TableAllCheckbox state by checking the selection completeness within selectable rows rather than all rows, as some pre-selected rows can be disabled i.e. not "selectable"

## QA steps

- [x] Ensure the component is displayed correctly across all breakpoints
- [x] Check the Selectable (Pre-selected) story in the storybook
- [x] Verify the "all checkbox" state is determined by the selectable row states, and disabled rows are ignored