### PR TITLE
feat(GenericTable): a11y and tab navigation improvements

### DIFF
--- a/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.tsx
+++ b/src/lib/components/GenericTable/ColumnHeader/ColumnHeader.tsx
@@ -15,13 +15,24 @@ type TableHeaderProps<T> = {
 
 const ColumnHeader = <T,>({ header }: TableHeaderProps<T>): ReactElement => {
   const canSort = header.column.getCanSort();
-  const isInteractiveHeader =
-    (header.column.columnDef.meta as { isInteractiveHeader?: boolean })?.isInteractiveHeader;
+  const meta = header.column.columnDef.meta as {
+    isInteractiveHeader?: boolean;
+    /** aria-label applied to the <th> — use for non-text headers like select checkboxes */
+    headerAriaLabel?: string;
+    /** Set true to hide the entire header cell from assistive technology */
+    headerAriaHidden?: boolean;
+  } | undefined;
+  const isInteractiveHeader = meta?.isInteractiveHeader;
 
   const renderedHeader = flexRender(header.column.columnDef.header, header.getContext());
 
   return (
-    <th className={classNames("p-column-header", header.column.id)} key={header.id}>
+    <th
+      aria-hidden={meta?.headerAriaHidden || undefined}
+      aria-label={meta?.headerAriaLabel}
+      className={classNames("p-column-header", header.column.id)}
+      key={header.id}
+    >
       {canSort && !isInteractiveHeader ? (
         <Button
           appearance="link"

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -117,9 +117,9 @@ const machineColumns: MachineColumnDef[] = [
     accessorKey: "id",
     header: "Actions",
     enableSorting: false,
-    cell: () => (
+    cell: ({row: {original: {fqdn}}}) => (
       <div className="actions-cell">
-        <Button appearance="base" hasIcon>
+        <Button aria-label={`Delete ${fqdn} machine.`} appearance="base" hasIcon>
           <Icon name="delete" />
         </Button>
       </div>
@@ -434,6 +434,7 @@ export const ConditionallySelectable: Story = {
                 position="btm-left"
               >
                 <Button
+                  aria-label={`Delete ${row.original.fqdn} machine.`}
                   disabled={!row.getCanSelect()}
                   appearance="base"
                   hasIcon
@@ -687,6 +688,7 @@ export const GroupedNested: Story = {
                 position="btm-left"
               >
                 <Button
+                  aria-label={`Delete ${row.original.fqdn} machine.`}
                   disabled={!row.getCanSelect()}
                   appearance="base"
                   hasIcon

--- a/src/lib/components/GenericTable/GenericTable.test.tsx
+++ b/src/lib/components/GenericTable/GenericTable.test.tsx
@@ -95,7 +95,7 @@ describe("GenericTable", () => {
       />,
     );
 
-    expect(screen.getByRole("grid", { name: "Images" })).toBeInTheDocument();
+    expect(screen.getByRole("treegrid", { name: "Images" })).toBeInTheDocument();
 
     expect(screen.getByText("Release title")).toBeInTheDocument();
     expect(screen.getByText("Architecture")).toBeInTheDocument();
@@ -120,7 +120,7 @@ describe("GenericTable", () => {
   it("renders loading state correctly", () => {
     render(<GenericTable columns={columns} data={data} isLoading={true} />);
 
-    const table = screen.getByRole("grid");
+    const table = screen.getByRole("treegrid");
     expect(table).toHaveAttribute("aria-busy", "true");
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
@@ -590,7 +590,7 @@ describe("GenericTable", () => {
       />,
     );
 
-    const table = screen.getByRole("grid");
+    const table = screen.getByRole("treegrid");
     expect(table).not.toHaveClass("p-generic-table__is-full-height");
 
     const containerRef = {
@@ -638,7 +638,7 @@ describe("GenericTable", () => {
       />,
     );
 
-    const fullHeightTable = screen.getAllByRole("grid")[1];
+    const fullHeightTable = screen.getAllByRole("treegrid")[1];
     expect(fullHeightTable).toHaveClass("p-generic-table__is-full-height");
   });
 
@@ -660,7 +660,7 @@ describe("GenericTable", () => {
 
     render(<TestComponent />);
 
-    expect(screen.getByRole("grid")).toBeInTheDocument();
+    expect(screen.getByRole("treegrid")).toBeInTheDocument();
 
     expect(global.ResizeObserver).toHaveBeenCalled();
 
@@ -682,7 +682,7 @@ describe("GenericTable", () => {
 
     const tableWrapper =
       screen.getByTestId("p-generic-table") ||
-      screen.getByRole("grid").closest(".p-generic-table");
+      screen.getByRole("treegrid").closest(".p-generic-table");
     expect(tableWrapper).toHaveClass("custom-table-class");
   });
 });

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -12,6 +12,7 @@ import {
   useMemo,
   useRef,
   useState,
+  KeyboardEvent,
 } from "react";
 
 import { Icon, ICONS, Spinner, Tooltip } from "@canonical/react-components";
@@ -148,6 +149,10 @@ export const GenericTable = <
   variant = "full-height",
   ...props
 }: GenericTableProps<T>): ReactElement => {
+  // Separate aria-label so it is applied only to <table>, not the outer <div>
+  const { "aria-label": tableAriaLabel, ...divProps } = props as typeof props & {
+    "aria-label"?: string;
+  };
   const tableRef = useRef<HTMLTableSectionElement>(null);
   const tableElRef = useRef<HTMLTableElement>(null);
   const [maxHeight, setMaxHeight] = useState("auto");
@@ -220,6 +225,7 @@ export const GenericTable = <
           id: "p-generic-table__select",
           accessorKey: "id",
           enableSorting: false,
+          meta: { headerAriaLabel: "Row selection" },
           header: ({ table }: HeaderContext<T, Partial<T>>) => {
             if (groupBy) {
               return "";
@@ -255,6 +261,7 @@ export const GenericTable = <
             id: "p-generic-table__group-select",
             accessorKey: "id",
             enableSorting: false,
+            meta: { headerAriaLabel: "Row selection" },
             header: ({ table }: HeaderContext<T, Partial<T>>) => (
               <TableCheckbox.All table={table} />
             ),
@@ -276,6 +283,7 @@ export const GenericTable = <
         id: "p-generic-table__group-chevron",
         accessorKey: "id",
         enableSorting: false,
+        meta: { headerAriaHidden: true },
         header: "",
         cell: ({ row }: CellContext<T, Partial<T>>) => {
           const isExpanded = row.getIsExpanded();
@@ -469,7 +477,7 @@ export const GenericTable = <
   const renderLoadingRows = () => {
     return (
       <tr>
-        <td className="p-generic-table__loading" colSpan={columns.length}>
+        <td className="p-generic-table__loading" colSpan={columns.length} role="gridcell">
           <Spinner text="Loading..." />
         </td>
       </tr>
@@ -481,14 +489,19 @@ export const GenericTable = <
     if (table.getRowModel().rows.length < 1) {
       return (
         <tr>
-          <td className="p-generic-table__no-data" colSpan={columns.length}>
+          <td className="p-generic-table__no-data" colSpan={columns.length} role="gridcell">
             {noData}
           </td>
         </tr>
       );
     }
 
+    // Sequential 1-based index; header row occupies index 1
+    let rowIndex = 1;
+
     return table.getRowModel().rows.map((row) => {
+      rowIndex++;
+      const currentRowIndex = rowIndex;
       const { getIsGrouped, id, getVisibleCells, parentId } = row;
       const isIndividualRow = !getIsGrouped();
       const isSelected =
@@ -505,7 +518,8 @@ export const GenericTable = <
 
       return (
         <tr
-          aria-rowindex={parseInt(id.replace(/\D/g, "") || "0", 10) + 1}
+          aria-expanded={!isIndividualRow ? row.getIsExpanded() : undefined}
+          aria-rowindex={currentRowIndex}
           aria-selected={isSelected}
           className={classNames({
             "p-generic-table__individual-row": isIndividualRow,
@@ -534,7 +548,7 @@ export const GenericTable = <
               return filterCells(row, cell.column);
             })
             .map((cell) => (
-              <td className={classNames(`${cell.column.id}`)} key={cell.id}>
+              <td className={classNames(`${cell.column.id}`)} key={cell.id} role="gridcell">
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </td>
             ))}
@@ -547,7 +561,7 @@ export const GenericTable = <
     <div
       className={classNames("p-generic-table", className)}
       data-testid="p-generic-table"
-      {...props}
+      {...divProps}
     >
       {pagination && (
         <PaginationBar
@@ -564,19 +578,19 @@ export const GenericTable = <
       <table
         ref={tableElRef}
         aria-busy={isLoading}
-        aria-label={props["aria-label"]}
-        aria-describedby="generic-table-description"
-        aria-rowcount={sortedData.length + 1} // +1 for header row
+        aria-label={tableAriaLabel}
+        aria-rowcount={table.getRowModel().rows.length + 1} // +1 for header row
         className={classNames("p-generic-table__table", {
           "p-generic-table__is-full-height": effectiveVariant === "full-height",
           "p-generic-table__is-selectable": canSelect,
           "p-generic-table__is-grouped": groupBy !== undefined,
         })}
-        role="grid"
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+        role="treegrid"
       >
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id} role="row">
+            <tr aria-rowindex={1} key={headerGroup.id} role="row">
               {headerGroup.headers
                 .filter(filterHeaders)
                 .map((header, index) => (
@@ -587,6 +601,7 @@ export const GenericTable = <
                     ((!showChevron && index === 2) ||
                       (showChevron && index === 3)) ? (
                       <th
+                        aria-hidden="true"
                         className="p-generic-table__select-alignment"
                         role="columnheader"
                       />

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -527,11 +527,7 @@ export const GenericTable = <
             "p-generic-table__nested-row":
               getSubRows !== undefined && !!parentId,
           })}
-          onClick={(e) => {
-            if (isIndividualRow) return;
-            if (e.target !== e.currentTarget) return;
-            row.toggleExpanded();
-          }}
+          onClick={!isIndividualRow ? () => row.toggleExpanded() : undefined}
           onKeyDown={!isIndividualRow ? handleGroupKeyDown : undefined}
           tabIndex={!isIndividualRow ? 0 : undefined}
           key={id}

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -149,6 +149,7 @@ export const GenericTable = <
   ...props
 }: GenericTableProps<T>): ReactElement => {
   const tableRef = useRef<HTMLTableSectionElement>(null);
+  const tableElRef = useRef<HTMLTableElement>(null);
   const [maxHeight, setMaxHeight] = useState("auto");
   const [needsScrolling, setNeedsScrolling] = useState(false);
 
@@ -401,6 +402,31 @@ export const GenericTable = <
     };
   }, [containerRef, sortedData.length, isLoading]); // Added dependencies to recalculate when data changes
 
+  // Safari does not include natively interactive elements (buttons, inputs,
+  // checkboxes, anchors) in the tab sequence when they are inside a
+  // display:block container such as this table's thead/tbody. Setting
+  // tabIndex=0 explicitly overrides Safari's broken heuristic without
+  // changing the DOM structure or CSS layout.
+  useEffect(() => {
+    const tableEl = tableElRef.current;
+    if (!tableEl || isLoading) return;
+
+    const selector = [
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "a[href]",
+    ].join(", ");
+
+    tableEl.querySelectorAll<HTMLElement>(selector).forEach((el) => {
+      // Respect elements intentionally removed from tab order (tabIndex="-1")
+      if (el.getAttribute("tabindex") !== "-1") {
+        el.tabIndex = 0;
+      }
+    });
+  }); // No dependency array: re-run after every render so new rows are covered
+
   // Determine the effective variant based on content and scrolling needs
   const effectiveVariant =
     variant === "full-height" && needsScrolling ? "full-height" : "regular";
@@ -469,6 +495,14 @@ export const GenericTable = <
         selection?.rowSelection !== undefined &&
         Object.keys(selection.rowSelection!).includes(id);
 
+      const handleGroupKeyDown = (e: KeyboardEvent<HTMLTableRowElement>) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          row.toggleExpanded();
+        }
+      };
+
       return (
         <tr
           aria-rowindex={parseInt(id.replace(/\D/g, "") || "0", 10) + 1}
@@ -479,10 +513,13 @@ export const GenericTable = <
             "p-generic-table__nested-row":
               getSubRows !== undefined && !!parentId,
           })}
-          onClick={() => {
+          onClick={(e) => {
             if (isIndividualRow) return;
+            if (e.target !== e.currentTarget) return;
             row.toggleExpanded();
           }}
+          onKeyDown={!isIndividualRow ? handleGroupKeyDown : undefined}
+          tabIndex={!isIndividualRow ? 0 : undefined}
           key={id}
           role="row"
         >
@@ -525,6 +562,7 @@ export const GenericTable = <
         />
       )}
       <table
+        ref={tableElRef}
         aria-busy={isLoading}
         aria-label={props["aria-label"]}
         aria-describedby="generic-table-description"

--- a/src/lib/components/GenericTable/PaginationBar/ControlsBar/ControlsBar.tsx
+++ b/src/lib/components/GenericTable/PaginationBar/ControlsBar/ControlsBar.tsx
@@ -1,8 +1,16 @@
 import type { PropsWithChildren, ReactElement } from "react";
 
-const ControlsBar = ({ children }: PropsWithChildren<object>): ReactElement => {
+type ControlsBarProps = PropsWithChildren<{ "aria-label"?: string }>;
+
+const ControlsBar = ({
+  children,
+  "aria-label": ariaLabel = "Table controls",
+}: ControlsBarProps): ReactElement => {
   return (
-    <section className="controls-bar u-flex u-flex--justify-between u-flex--wrap">
+    <section
+      aria-label={ariaLabel}
+      className="controls-bar u-flex u-flex--justify-between u-flex--wrap"
+    >
       <div className="p-form p-form--inline">{children}</div>
     </section>
   );

--- a/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
+++ b/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
@@ -88,26 +88,17 @@ describe("TableCheckbox.All", () => {
 
   it("displays 'unchecked' when no selectable rows are selected", () => {
     renderSelectAllCheckbox([selectable(false), selectable(false)]);
-    expect(screen.getByRole("checkbox")).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
   });
 
   it("displays 'mixed' when some selectable rows are selected", () => {
     renderSelectAllCheckbox([selectable(true), selectable(false)]);
-    expect(screen.getByRole("checkbox")).toHaveAttribute(
-      "aria-checked",
-      "mixed",
-    );
+    expect(screen.getByRole("checkbox")).toBePartiallyChecked();
   });
 
   it("displays 'checked' when all selectable rows are selected", () => {
     renderSelectAllCheckbox([selectable(true), selectable(true)]);
-    expect(screen.getByRole("checkbox")).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
+    expect(screen.getByRole("checkbox")).toBeChecked();
   });
 
   it("is disabled when there are no selectable rows", () => {
@@ -171,10 +162,7 @@ describe("TableCheckbox.Group", () => {
     renderSelectGroupCheckbox({
       subRows: [selectableSub(true), selectableSub(false)],
     });
-    expect(screen.getByRole("checkbox")).toHaveAttribute(
-      "aria-checked",
-      "mixed",
-    );
+    expect(screen.getByRole("checkbox")).toBePartiallyChecked();
   });
 
   it("shows checked when all selectable sub-rows are selected", () => {

--- a/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
+++ b/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
@@ -33,8 +33,7 @@ const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
   const isAllSelected =
     selectableRows.length > 0 &&
     selectedSelectableRows.length === selectableRows.length;
-  const isIndeterminate =
-    selectedSelectableRows.length > 0 && !isAllSelected;
+  const isIndeterminate = selectedSelectableRows.length > 0 && !isAllSelected;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
@@ -44,7 +43,12 @@ const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
   }, [isIndeterminate]);
 
   return (
-    <label className="p-checkbox--inline p-table-checkbox--all">
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <label
+      className="p-checkbox--inline p-table-checkbox--all"
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
       <input
         ref={checkboxRef}
         aria-label="select all"
@@ -91,7 +95,12 @@ const TableGroupCheckbox = <T,>({ row, ...props }: TableCheckboxProps<T>) => {
   }, [isSomeSelectableSelected]);
 
   return (
-    <label className="p-checkbox--inline p-table-checkbox--group">
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <label
+      className="p-checkbox--inline p-table-checkbox--group"
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
       <input
         ref={checkboxRef}
         className="p-checkbox__input"
@@ -135,15 +144,17 @@ const TableCheckbox = <T,>({
   const tooltipMessage = isNested
     ? "Selection is managed by the parent row"
     : !canSelect
-    ? disabledTooltipMessage
-    : false;
+      ? disabledTooltipMessage
+      : false;
 
   return (
-    <Tooltip
-      message={tooltipMessage}
-      position="btm-right"
-    >
-      <label className="p-checkbox--inline p-table-checkbox">
+    <Tooltip message={tooltipMessage} position="btm-right">
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+      <label
+        className="p-checkbox--inline p-table-checkbox"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <input
           className="p-checkbox__input"
           type="checkbox"

--- a/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
+++ b/src/lib/components/GenericTable/TableCheckbox/TableCheckbox.tsx
@@ -3,6 +3,7 @@ import type {
   InputHTMLAttributes,
   ReactElement,
 } from "react";
+import { useEffect, useRef } from "react";
 
 import { Tooltip } from "@canonical/react-components";
 import type { Row, Table } from "@tanstack/react-table";
@@ -15,6 +16,8 @@ type TableCheckboxProps<T> = Partial<
 };
 
 const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
+  const checkboxRef = useRef<HTMLInputElement>(null);
+
   if (!table) {
     return null;
   }
@@ -27,36 +30,35 @@ const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
     .getSelectedRowModel()
     .rows.filter((row) => row.getCanSelect());
 
-  let checked: boolean | "false" | "mixed" | "true" | undefined;
-  if (selectedSelectableRows.length === 0) {
-    checked = "false";
-  } else if (selectedSelectableRows.length < selectableRows.length) {
-    checked = "mixed";
-  } else {
-    checked = "true";
-  }
+  const isAllSelected =
+    selectableRows.length > 0 &&
+    selectedSelectableRows.length === selectableRows.length;
+  const isIndeterminate =
+    selectedSelectableRows.length > 0 && !isAllSelected;
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    if (checkboxRef.current) {
+      checkboxRef.current.indeterminate = isIndeterminate;
+    }
+  }, [isIndeterminate]);
 
   return (
     <label className="p-checkbox--inline p-table-checkbox--all">
       <input
-        aria-checked={checked}
+        ref={checkboxRef}
         aria-label="select all"
         className="p-checkbox__input"
         disabled={selectableRows.length === 0}
         type="checkbox"
-        {...{
-          checked: checked === "true",
-          onChange: () => {
-            const selectableRows = table
-              .getCoreRowModel()
-              .rows.filter((row) => row.getCanSelect());
+        checked={isAllSelected}
+        onChange={() => {
+          const rows = table
+            .getCoreRowModel()
+            .rows.filter((row) => row.getCanSelect());
 
-            const allSelected = selectableRows.every((row) =>
-              row.getIsSelected(),
-            );
-
-            selectableRows.forEach((row) => row.toggleSelected(!allSelected));
-          },
+          const allSelected = rows.every((row) => row.getIsSelected());
+          rows.forEach((row) => row.toggleSelected(!allSelected));
         }}
         {...props}
       />
@@ -66,6 +68,8 @@ const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
 };
 
 const TableGroupCheckbox = <T,>({ row, ...props }: TableCheckboxProps<T>) => {
+  const checkboxRef = useRef<HTMLInputElement>(null);
+
   if (!row) {
     return null;
   }
@@ -80,13 +84,16 @@ const TableGroupCheckbox = <T,>({ row, ...props }: TableCheckboxProps<T>) => {
   const isSomeSelectableSelected =
     selectedCount > 0 && !isAllSelectableSelected;
 
+  useEffect(() => {
+    if (checkboxRef.current) {
+      checkboxRef.current.indeterminate = isSomeSelectableSelected;
+    }
+  }, [isSomeSelectableSelected]);
+
   return (
-    <label
-      aria-disabled={!row.getCanSelect()}
-      className="p-checkbox--inline p-table-checkbox--group"
-    >
+    <label className="p-checkbox--inline p-table-checkbox--group">
       <input
-        aria-checked={isSomeSelectableSelected ? "mixed" : undefined}
+        ref={checkboxRef}
         className="p-checkbox__input"
         type="checkbox"
         checked={isAllSelectableSelected}
@@ -117,26 +124,32 @@ const TableCheckbox = <T,>({
     return null;
   }
 
+  const canSelect = row.getCanSelect();
+
   const disabledTooltipMessage =
     typeof disabledTooltip === "string"
       ? disabledTooltip
       : disabledTooltip(row);
 
+  // Explain why the checkbox is disabled regardless of cause
+  const tooltipMessage = isNested
+    ? "Selection is managed by the parent row"
+    : !canSelect
+    ? disabledTooltipMessage
+    : false;
+
   return (
     <Tooltip
-      message={!row.getCanSelect() && disabledTooltipMessage}
+      message={tooltipMessage}
       position="btm-right"
     >
-      <label
-        aria-disabled={!row.getCanSelect()}
-        className="p-checkbox--inline p-table-checkbox"
-      >
+      <label className="p-checkbox--inline p-table-checkbox">
         <input
           className="p-checkbox__input"
           type="checkbox"
           {...{
             checked: row.getIsSelected(),
-            disabled: !row.getCanSelect() || isNested,
+            disabled: !canSelect || isNested,
             onChange: row.getToggleSelectedHandler(),
           }}
           {...props}

--- a/src/lib/components/Pagination/Pagination.tsx
+++ b/src/lib/components/Pagination/Pagination.tsx
@@ -1,10 +1,10 @@
-import { ChangeEvent, useState } from "react";
+import { AriaAttributes, ChangeEvent, FC, useState } from "react";
 
 import "./Pagination.scss";
 import { Button, Icon, Input } from "@canonical/react-components";
 import classNames from "classnames";
 
-export interface PaginationProps extends React.AriaAttributes {
+export interface PaginationProps extends AriaAttributes {
   className?: string;
   currentPage: number | undefined;
   error?: string;
@@ -16,7 +16,7 @@ export interface PaginationProps extends React.AriaAttributes {
   totalPages: number;
 }
 
-export const Pagination: React.FC<PaginationProps> = ({
+export const Pagination: FC<PaginationProps> = ({
   className,
   currentPage,
   error,
@@ -41,7 +41,7 @@ export const Pagination: React.FC<PaginationProps> = ({
           onClick={onPreviousClick}
           type="button"
         >
-          <Icon name="chevron-down" />
+          <Icon name="chevron-left" />
         </Button>
         <strong>Page </strong>{" "}
         <Input
@@ -49,6 +49,7 @@ export const Pagination: React.FC<PaginationProps> = ({
           className="p-pagination__input"
           disabled={disabled}
           error={error}
+          max={totalPages}
           min={1}
           onBlur={onInputBlur}
           onChange={onInputChange}
@@ -64,7 +65,7 @@ export const Pagination: React.FC<PaginationProps> = ({
           onClick={onNextClick}
           type="button"
         >
-          <Icon name="chevron-up" />
+          <Icon name="chevron-right" />
         </Button>
       </span>
     </nav>
@@ -78,7 +79,7 @@ export interface PaginationContainerProps {
   totalPages: PaginationProps["totalPages"];
 }
 
-export const PaginationContainer: React.FC<PaginationContainerProps> = ({
+export const PaginationContainer: FC<PaginationContainerProps> = ({
   currentPage,
   disabled,
   paginate,


### PR DESCRIPTION
## Done

- Added aria-labels for auxiliary elements e.g. ControlsBar & Pagination
- aria-label and aria-hidden metas for ColumnHeaders
- Switched to using ref indeterminate prop instead of "mixed" for checkbox states
- Fixed GenericTable tab navigation in Safari (issue caused by Safari disregarding interactibles within display: block containers)
- Added proper aria roles, labels, and row indices in GenericTable
- Fixed GenericTable story column definition to have clean AXE violation reports in Storybook

## QA steps

- [x] Open Storybook in Chrome
- [x] Ensure the component is displayed correctly across all breakpoints
- [x] Ensure the component is displayed as expected across all stories
- [x] Open the Grouped (Selectable) story
- [x] Make the component preview full screen
- [x] Navigate the full screen preview page using tab
- [x] Verify you can access all interactible elements of the table using tabs
- [x] Verify you can use Space to toggle checkboxes
- [x] Verify you can use Space/Enter to sort columns
- [x] Verify you can use Space/Enter to expand/collapse groups
- [x] Verify you can focus and Space/Enter the row action buttons (feel free to add `onClick={() => console.log("clicked")}` to the action buttons to ensure)
- [x] Exit the fullscreen preview and return to the main Storybook page
- [x] Iterate through GenericTable stories, and verify they have no reported violations (under the "Accessibility" tab at the bottom of the page)
- [ ] [Optional] Repeat for Firefox
- [ ] [Optional] Repeat for Safari
- [ ] [Optional] If you have the AXE DevTools plugin installed on Chrome, verify that there are no accessibility violations reported for the GenericTable by running it on the "Docs" page for GenericTable (some violations will be reported on the Storybook page itself)
