### PR TITLE
feat(Placeholder): pulse placeholder with box display

### DIFF
--- a/src/lib/components/GenericTable/GenericTable.scss
+++ b/src/lib/components/GenericTable/GenericTable.scss
@@ -160,30 +160,6 @@
         background: transparent !important;
       }
     }
-
-    .p-generic-table__skeleton-default {
-      display: inline-block;
-      height: 3 * $sp-unit;
-      width: 70%;
-      background: linear-gradient(
-        90deg,
-        var(--vf-color-background-alt, #{$color-mid-light}) 25%,
-        var(--vf-color-background-default, #{$color-light}) 50%,
-        var(--vf-color-background-alt, #{$color-mid-light}) 75%
-      );
-      background-size: 200% 100%;
-      animation: p-generic-table-skeleton-shimmer 1.4s ease-in-out infinite;
-    }
-  }
-}
-
-@keyframes p-generic-table-skeleton-shimmer {
-  0% {
-    background-position: 200% center;
-  }
-
-  100% {
-    background-position: -200% center;
   }
 }
 

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -16,6 +16,7 @@ import {
 } from "@tanstack/react-table";
 
 import { GenericTable } from "@/lib/components/GenericTable/GenericTable";
+import { Placeholder } from "@/lib/elements/Placeholder/Placeholder";
 
 type Machine = {
   id: number;
@@ -390,14 +391,12 @@ export const LoadingCustomSkeleton: Story = {
                 gap: "0.1rem",
               }}
             >
-              <div className="p-generic-table__skeleton-default" />
-              <div
-                style={{
-                  width: "50%",
-                  height: "1rem",
-                  marginTop: "0.25rem",
-                }}
-                className="p-generic-table__skeleton-default"
+              <Placeholder variant="block" width="100%" height="1.5rem" />
+              <Placeholder
+                variant="block"
+                width="50%"
+                height="1rem"
+                style={{ marginTop: "0.25rem" }}
               />
             </div>
           ),
@@ -407,10 +406,7 @@ export const LoadingCustomSkeleton: Story = {
         ...machineColumns[1],
         meta: {
           skeleton: () => (
-            <div
-              style={{ width: "50%" }}
-              className="p-generic-table__skeleton-default"
-            />
+            <Placeholder variant="block" width="50%" height="1.5rem" />
           ),
         },
       },
@@ -421,10 +417,7 @@ export const LoadingCustomSkeleton: Story = {
         meta: {
           cellAriaLabel: (row) => `Actions for ${row.original.fqdn}`,
           skeleton: () => (
-            <div
-              style={{ width: "2rem" }}
-              className="p-generic-table__skeleton-default"
-            />
+            <Placeholder variant="block" width="2rem" height="1.5rem" />
           ),
         },
       },

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -82,7 +82,7 @@ type GenericTableProps<T extends GenericTableData> = {
  * @param {(originalRow: T, index: number) => T[] | undefined} [props.getSubRows] - Function that returns the T.prop that contains nested T data
  * @param {string[]} [props.groupBy] - Column IDs to group rows by
  * @param {boolean} props.isLoading - Loading state to display placeholder content
- * @param {"spinner" | "skeleton"} [props.loadingVariant="spinner"] - Loading display style; "spinner" shows a single spinner row, "skeleton" renders skeletonRowCount shimmer rows using meta.skeleton per column when defined, falling back to a default shimmer bar
+ * @param {"spinner" | "skeleton"} [props.loadingVariant="spinner"] - Loading display style; "spinner" shows a single spinner row, "skeleton" renders skeletonRowCount pulsing skeleton rows using meta.skeleton per column when defined, falling back to a default Placeholder block
  * @param {number} [props.skeletonRowCount=10] - Number of skeleton rows to render when loadingVariant="skeleton"
  * @param {ReactNode} [props.noData] - Content to display when no data is available
  * @param {PaginationBarProps} [props.pagination] - Pagination configuration

--- a/src/lib/components/GenericTable/utils/renderLoadingRows.tsx
+++ b/src/lib/components/GenericTable/utils/renderLoadingRows.tsx
@@ -3,6 +3,7 @@ import { ColumnDef, Header, Table } from "@tanstack/react-table";
 import classNames from "classnames";
 
 import { GenericTableData } from "@/lib/components/GenericTable/types";
+import { Placeholder } from "@/lib/elements/Placeholder/Placeholder";
 
 export const renderLoadingRows = <T extends GenericTableData>({
   table,
@@ -57,7 +58,7 @@ export const renderLoadingRows = <T extends GenericTableData>({
             {isInjectedColumn ? null : meta?.skeleton ? (
               meta.skeleton()
             ) : (
-              <div className="p-generic-table__skeleton-default" />
+              <Placeholder variant="block" width="70%" height="1.5rem" />
             )}
           </td>
         );

--- a/src/lib/elements/Placeholder/Placeholder.scss
+++ b/src/lib/elements/Placeholder/Placeholder.scss
@@ -2,9 +2,9 @@
 
 .p-placeholder {
   animation: placeholder-pulse 1.5s ease-in-out infinite;
-  background-color: $color-mid-x-light;
+  background-color: var(--vf-color-background-active);
   border-radius: 0.25rem;
-  display: block;
+  display: inline-block;
   pointer-events: none;
 }
 

--- a/src/lib/elements/Placeholder/Placeholder.scss
+++ b/src/lib/elements/Placeholder/Placeholder.scss
@@ -1,27 +1,28 @@
 @import "vanilla-framework";
 
 .p-placeholder {
-  animation: shine 1.5s infinite ease-out;
+  animation: placeholder-pulse 1.5s ease-in-out infinite;
   background-color: $color-mid-x-light;
-  background-image: linear-gradient(
-    to right,
-    $color-mid-x-light calc(50% - 2rem),
-    $color-light 50%,
-    $color-mid-x-light calc(50% + 2rem)
-  );
-  background-size: 300% 100%;
-  color: transparent;
-  overflow: hidden;
+  border-radius: 0.25rem;
+  display: block;
   pointer-events: none;
-  text-indent: -100%;
 }
 
-@keyframes shine {
-  0% {
-    background-position: right;
+.p-placeholder__sizer {
+  // Sizes to its own content so the parent can use width: fit-content to match.
+  color: transparent;
+  display: inline-block;
+  pointer-events: none;
+  user-select: none;
+}
+
+@keyframes placeholder-pulse {
+  0%,
+  100% {
+    opacity: 1;
   }
 
-  100% {
-    background-position: left;
+  50% {
+    opacity: 0.4;
   }
 }

--- a/src/lib/elements/Placeholder/Placeholder.stories.tsx
+++ b/src/lib/elements/Placeholder/Placeholder.stories.tsx
@@ -1,3 +1,5 @@
+// noinspection JSUnusedGlobalSymbols -- Storybook story exports are consumed by
+// the Storybook runtime, not by TypeScript imports. The IDE cannot see that usage.
 import { Meta, StoryObj } from "@storybook/react";
 
 import { Placeholder } from "@/lib/elements/Placeholder/Placeholder";
@@ -10,20 +12,161 @@ const meta: Meta<typeof Placeholder> = {
     status: {
       type: "candidate",
     },
+    docs: {
+      description: {
+        component:
+          "Placeholder is a pulsing skeleton block used to represent content that is still loading. " +
+          "Pass `width` and `height` to size the block explicitly, or compose multiple instances " +
+          "to mirror the layout of the real content. The legacy `isPending`/`text`/`children` API " +
+          "is still supported but deprecated — prefer conditional rendering at the call-site instead.",
+      },
+    },
+  },
+  args: {
+    variant: "block",
+  },
+  argTypes: {
+    // Dimensions
+    width: {
+      description:
+        'Width of the skeleton block. Accepts any valid CSS value (e.g. "200px", "100%", "12rem"). ' +
+        "When omitted the block stretches to fill its container.",
+      control: { type: "text" },
+      table: {
+        type: { summary: 'CSSProperties["width"]' },
+        category: "Dimensions",
+      },
+    },
+    height: {
+      description:
+        'Height of the skeleton block. Accepts any valid CSS value (e.g. "1rem", "48px", "3em"). ' +
+        "When omitted the block collapses unless a sizer or explicit content provides height.",
+      control: { type: "text" },
+      table: {
+        type: { summary: 'CSSProperties["height"]' },
+        category: "Dimensions",
+      },
+    },
+
+    // Appearance
+    variant: {
+      description:
+        'Rendering variant. `"block"` renders a standalone skeleton div sized by `width` and `height`. ' +
+        '`"text"` is the legacy variant that requires `isPending` to control visibility.',
+      control: { type: "radio" },
+      options: ["block", "text"],
+      table: {
+        type: { summary: '"block" | "text"' },
+        defaultValue: { summary: '"text"' },
+        category: "Appearance",
+      },
+    },
+    className: {
+      description: "Additional CSS class names applied to the root element.",
+      control: { type: "text" },
+      table: {
+        type: { summary: "string" },
+        category: "Appearance",
+      },
+    },
+
+    // Deprecated
+    isPending: {
+      description:
+        "**Deprecated.** Use conditional rendering at the call-site instead. " +
+        "When `true` the skeleton is shown; when `false` the `children` are rendered. " +
+        "Will be removed in a future major version.",
+      control: { type: "boolean" },
+      table: {
+        type: { summary: "boolean" },
+        category: "Deprecated",
+      },
+    },
+    text: {
+      description:
+        "**Deprecated.** Width is now controlled via the `width` prop. " +
+        "When provided the text is rendered inside a visually-hidden sizer span " +
+        "that gives the block its natural content width. Will be removed in a future major version.",
+      control: { type: "text" },
+      table: {
+        type: { summary: "string" },
+        category: "Deprecated",
+      },
+    },
+    children: {
+      description:
+        "**Deprecated.** Pass children outside the Placeholder and control visibility at the call-site. " +
+        "Will be removed in a future major version.",
+      control: false,
+      table: {
+        type: { summary: "ReactNode" },
+        category: "Deprecated",
+      },
+    },
   },
 };
 
 export default meta;
 
-export const TextExample: StoryObj<typeof Placeholder> = {
+type Story = StoryObj<typeof Placeholder>;
+
+export const TextLine: Story = {
   args: {
+    width: "200px",
+    height: "1rem",
+  },
+};
+
+export const Paragraph: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+      <Placeholder width="100%" height="1rem" variant="block" />
+      <Placeholder width="100%" height="1rem" variant="block" />
+      <Placeholder width="60%" height="1rem" variant="block" />
+    </div>
+  ),
+};
+
+export const Block: Story = {
+  args: {
+    width: "3rem",
+    height: "3rem",
+  },
+};
+
+export const Complex: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", alignItems: "flex-start" }}>
+      <Placeholder width="3rem" height="3rem" variant="block" />
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5rem",
+          flex: 1,
+        }}
+      >
+        <Placeholder width="40%" height="1rem" variant="block" />
+        <Placeholder width="100%" height="0.875rem" variant="block" />
+        <Placeholder width="80%" height="0.875rem" variant="block" />
+      </div>
+    </div>
+  ),
+};
+
+export const LegacyTextProp: Story = {
+  name: "Legacy (text prop)",
+  args: {
+    variant: "text",
     isPending: true,
     text: "XXXxxxx.xxxxxxxxx",
   },
 };
 
-export const ComponentExample: StoryObj<typeof Placeholder> = {
+export const LegacyChildrenProp: Story = {
+  name: "Legacy (children prop)",
   args: {
+    variant: "text",
     isPending: true,
     children: <span>XXXxxxx.xxxxxxxxx</span>,
   },

--- a/src/lib/elements/Placeholder/Placeholder.test.tsx
+++ b/src/lib/elements/Placeholder/Placeholder.test.tsx
@@ -1,30 +1,130 @@
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 
-import { Placeholder } from "./Placeholder";
+import { Placeholder } from "@/lib";
 
-it("always hides placeholder text passed as a text prop", async () => {
-  const { rerender } = render(<Placeholder text="Placeholder text" />);
-  expect(screen.queryByText(/Placeholder text/)).not.toBeInTheDocument();
-  rerender(<Placeholder isPending text="Placeholder text" />);
-  expect(screen.queryByText(/Placeholder text/)).toHaveAttribute(
-    "aria-hidden",
-    "true",
-  );
-});
+describe("Placeholder", () => {
+  it("renders a skeleton block with role progressbar", () => {
+    render(<Placeholder variant="block" />);
+    expect(
+      screen.getByRole("progressbar", { name: /loading/i }),
+    ).toBeInTheDocument();
+  });
 
-it("hides the children when loading", async () => {
-  const { rerender } = render(<Placeholder>Placeholder children</Placeholder>);
-  expect(screen.getByText(/Placeholder children/)).toBeInTheDocument();
-  rerender(<Placeholder isPending>Placeholder children</Placeholder>);
-  expect(screen.queryByText(/Placeholder children/)).toHaveAttribute(
-    "aria-hidden",
-    "true",
-  );
-});
+  it("applies a width CSS string as an inline style", () => {
+    render(<Placeholder variant="block" width="200px" />);
+    const el = screen.getByRole("progressbar", { name: /loading/i });
+    expect(el).toHaveStyle({ width: "200px" });
+  });
 
-it("does not return placeholder styles when isPending is false", async () => {
-  const { rerender } = render(<Placeholder>Placeholder children</Placeholder>);
-  expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument();
-  rerender(<Placeholder isPending>Placeholder children</Placeholder>);
-  expect(screen.getByLabelText(/loading/i)).toBeInTheDocument();
+  it("applies a height CSS string as an inline style", () => {
+    render(<Placeholder variant="block" height="3rem" />);
+    const el = screen.getByRole("progressbar", { name: /loading/i });
+    expect(el).toHaveStyle({ height: "3rem" });
+  });
+
+  it("applies both width and height at the same time", () => {
+    render(<Placeholder variant="block" width="100%" height="1.5rem" />);
+    const el = screen.getByRole("progressbar", { name: /loading/i });
+    expect(el).toHaveStyle({ width: "100%", height: "1.5rem" });
+  });
+
+  it("forwards extra className to the root element", () => {
+    render(<Placeholder variant="block" className="custom-class" />);
+    expect(screen.getByRole("progressbar", { name: /loading/i })).toHaveClass(
+      "p-placeholder",
+      "custom-class",
+    );
+  });
+
+  it("does not render a sizer span when an explicit width is supplied alongside text", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    render(
+      <Placeholder variant="block" text="XXXxxxx.xxxxxxxxx" width="300px" />,
+    );
+    expect(screen.queryByText("XXXxxxx.xxxxxxxxx")).not.toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: /loading/i })).toHaveStyle({
+      width: "300px",
+    });
+    vi.restoreAllMocks();
+  });
+
+  describe("deprecated", () => {
+    beforeEach(() => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("renders the skeleton when isPending is true", () => {
+      render(<Placeholder isPending text="Placeholder text" />);
+      expect(
+        screen.getByRole("progressbar", { name: /loading/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("applies fit-content width so the block matches the sizer when no explicit width is set", () => {
+      render(<Placeholder isPending text="Placeholder text" />);
+      expect(screen.getByRole("progressbar", { name: /loading/i })).toHaveStyle(
+        {
+          width: "fit-content",
+        },
+      );
+    });
+
+    it("uses the explicit width prop instead of fit-content when one is provided", () => {
+      render(<Placeholder isPending text="Placeholder text" width="250px" />);
+      expect(screen.getByRole("progressbar", { name: /loading/i })).toHaveStyle(
+        {
+          width: "250px",
+        },
+      );
+    });
+
+    it("hides the text content via aria-hidden when isPending is true", () => {
+      render(<Placeholder isPending text="Placeholder text" />);
+      const sizer = screen.queryByText(/Placeholder text/);
+      expect(sizer).toHaveAttribute("aria-hidden", "true");
+      expect(sizer).toHaveClass("p-placeholder__sizer");
+    });
+
+    it("renders children and no skeleton when isPending is false", () => {
+      render(<Placeholder isPending={false}>Placeholder children</Placeholder>);
+      expect(screen.getByText(/Placeholder children/)).toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+
+    it("hides children via aria-hidden when isPending is true", () => {
+      render(<Placeholder isPending>Placeholder children</Placeholder>);
+      expect(screen.queryByText(/Placeholder children/)).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+    });
+
+    it("emits a deprecation warning for isPending", () => {
+      render(<Placeholder isPending />);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("`isPending` prop is deprecated"),
+      );
+    });
+
+    it("emits a deprecation warning for text", () => {
+      render(<Placeholder isPending text="foo" />);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("`text` prop is deprecated"),
+      );
+    });
+
+    it("emits a deprecation warning for children", () => {
+      render(<Placeholder isPending>foo</Placeholder>);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Passing `children` to Placeholder is deprecated",
+        ),
+      );
+    });
+  });
 });

--- a/src/lib/elements/Placeholder/Placeholder.tsx
+++ b/src/lib/elements/Placeholder/Placeholder.tsx
@@ -1,40 +1,115 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactElement, ReactNode } from "react";
+import { useEffect } from "react";
 import "./Placeholder.scss";
 
 import classNames from "classnames";
 
-export type PlaceholderProps = {
+type PlaceholderProps = {
   className?: string;
+  width?: CSSProperties["width"];
+  height?: CSSProperties["height"];
+  /** @deprecated */
   isPending?: boolean;
-} & (
-  | {
-      text?: never;
-      children?: ReactNode;
-    }
-  | {
-      text?: string;
-      children?: never;
-    }
-);
+  /** @deprecated */
+  text?: string;
+  /** @deprecated */
+  children?: ReactNode;
+  variant?: "block" | "text";
+};
 
+/**
+ * Placeholder - A pulsing skeleton block used to represent loading content
+ *
+ * Renders a rectangular block with a pulse animation that matches the dimensions
+ * of the content it is replacing. Use `width` and `height` to control the size
+ * explicitly, or rely on the default block layout for full-width skeletons.
+ *
+ * @param {Object} props - Component props
+ * @param {string} [props.className] - Additional CSS class names applied to the root element
+ * @param {CSSProperties["width"]} [props.width] - Width of the skeleton block; accepts any valid CSS value (e.g. "200px", "100%", "12rem"). When omitted the block stretches to fill its container
+ * @param {CSSProperties["height"]} [props.height] - Height of the skeleton block; accepts any valid CSS value (e.g. "1rem", "48px", "3em"). When omitted the block collapses unless content or a sizer provides height
+ * @param {"block" | "text"} [props.variant="text"] - Rendering variant. `"block"` renders a standalone skeleton div; `"text"` is the legacy variant that requires `isPending` to be set
+ * @param {boolean} [props.isPending] - @deprecated Use conditional rendering at the call-site instead. When `true` the skeleton is shown; when `false` the `children` are rendered. Will be removed in a future major version
+ * @param {string} [props.text] - @deprecated Width is now controlled via the `width` prop. When provided the text is rendered in a visually-hidden sizer span that gives the block its natural content width. Will be removed in a future major version
+ * @param {ReactNode} [props.children] - @deprecated Pass children outside the Placeholder and control visibility at the call-site. Will be removed in a future major version
+ *
+ * @returns {ReactElement} The rendered skeleton block, or the children when `isPending` is `false`
+ *
+ * @example
+ * // Standalone skeleton block
+ * <Placeholder width="200px" height="1rem" />
+ *
+ * @example
+ * // Composed loading state
+ * {isLoading ? <Placeholder width="100%" height="1.5rem" /> : <p>{content}</p>}
+ */
 export const Placeholder = ({
+  className,
+  width,
+  height,
+  isPending,
   text,
   children,
-  className,
-  isPending = false,
-}: PlaceholderProps) => {
-  const delay = Math.floor(Math.random() * 750);
-  if (isPending) {
+  variant = "text",
+}: PlaceholderProps): ReactElement => {
+  useEffect(() => {
+    if (isPending !== undefined) {
+      console.warn(
+        "[Placeholder] The `isPending` prop is deprecated and will be removed in a future major version. " +
+          "Control skeleton visibility with conditional rendering at the call-site instead.",
+      );
+    }
+  }, [isPending]);
+
+  useEffect(() => {
+    if (text !== undefined) {
+      console.warn(
+        "[Placeholder] The `text` prop is deprecated and will be removed in a future major version. " +
+          "Use the `width` prop to set the skeleton width.",
+      );
+    }
+  }, [text]);
+
+  useEffect(() => {
+    if (children !== undefined) {
+      console.warn(
+        "[Placeholder] Passing `children` to Placeholder is deprecated and will be removed in a future major version. " +
+          "Render children outside the Placeholder and control visibility at the call-site.",
+      );
+    }
+  }, [children]);
+
+  // Legacy behavior
+  if (variant === "text") {
+    if (!isPending) {
+      return <>{children}</>;
+    }
+    const delay = Math.floor(Math.random() * 750);
+    // When no explicit width is set, let the hidden sizer content drive the width.
+    const legacyWidth = width ?? "fit-content";
     return (
-      <span
+      <div
         aria-label="loading"
         className={classNames("p-placeholder", className)}
         role="progressbar"
-        style={{ animationDelay: `${delay}ms` }}
+        style={{ animationDelay: `${delay}ms`, width: legacyWidth, height }}
       >
-        <span aria-hidden="true">{text || children || "Loading"}</span>
-      </span>
+        {/* Hidden sizer: makes the block exactly as wide as the text/children */}
+        <span aria-hidden="true" className="p-placeholder__sizer">
+          {text || children || "Loading"}
+        </span>
+      </div>
     );
   }
-  return <>{children}</>;
+
+  // New behavior
+  const resolvedWidth = text && !width ? "fit-content" : width;
+  return (
+    <div
+      aria-label="loading"
+      className={classNames("p-placeholder", className)}
+      role="progressbar"
+      style={{ width: resolvedWidth, height }}
+    />
+  );
 };

--- a/src/lib/elements/Placeholder/Placeholder.tsx
+++ b/src/lib/elements/Placeholder/Placeholder.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactElement, ReactNode } from "react";
+import type { CSSProperties, HTMLAttributes, ReactElement, ReactNode } from "react";
 import { useEffect } from "react";
 import "./Placeholder.scss";
 
@@ -15,7 +15,7 @@ type PlaceholderProps = {
   /** @deprecated */
   children?: ReactNode;
   variant?: "block" | "text";
-};
+} & Omit<HTMLAttributes<HTMLDivElement>, "children">;
 
 /**
  * Placeholder - A pulsing skeleton block used to represent loading content
@@ -29,6 +29,7 @@ type PlaceholderProps = {
  * @param {CSSProperties["width"]} [props.width] - Width of the skeleton block; accepts any valid CSS value (e.g. "200px", "100%", "12rem"). When omitted the block stretches to fill its container
  * @param {CSSProperties["height"]} [props.height] - Height of the skeleton block; accepts any valid CSS value (e.g. "1rem", "48px", "3em"). When omitted the block collapses unless content or a sizer provides height
  * @param {"block" | "text"} [props.variant="text"] - Rendering variant. `"block"` renders a standalone skeleton div; `"text"` is the legacy variant that requires `isPending` to be set
+ * @param {HTMLAttributes<HTMLDivElement>} [props.style] - Any HTML div attributes (e.g. `style`, `data-*`, `aria-*`) are forwarded to the root element. `style` is merged with the component's internal width/height styles, with consumer values taking precedence
  * @param {boolean} [props.isPending] - @deprecated Use conditional rendering at the call-site instead. When `true` the skeleton is shown; when `false` the `children` are rendered. Will be removed in a future major version
  * @param {string} [props.text] - @deprecated Width is now controlled via the `width` prop. When provided the text is rendered in a visually-hidden sizer span that gives the block its natural content width. Will be removed in a future major version
  * @param {ReactNode} [props.children] - @deprecated Pass children outside the Placeholder and control visibility at the call-site. Will be removed in a future major version
@@ -51,6 +52,8 @@ export const Placeholder = ({
   text,
   children,
   variant = "text",
+  style,
+  ...divProps
 }: PlaceholderProps): ReactElement => {
   useEffect(() => {
     if (isPending !== undefined) {
@@ -92,7 +95,8 @@ export const Placeholder = ({
         aria-label="loading"
         className={classNames("p-placeholder", className)}
         role="progressbar"
-        style={{ animationDelay: `${delay}ms`, width: legacyWidth, height }}
+        style={{ animationDelay: `${delay}ms`, width: legacyWidth, height, ...style }}
+        {...divProps}
       >
         {/* Hidden sizer: makes the block exactly as wide as the text/children */}
         <span aria-hidden="true" className="p-placeholder__sizer">
@@ -109,7 +113,8 @@ export const Placeholder = ({
       aria-label="loading"
       className={classNames("p-placeholder", className)}
       role="progressbar"
-      style={{ width: resolvedWidth, height }}
+      style={{ width: resolvedWidth, height, ...style }}
+      {...divProps}
     />
   );
 };


### PR DESCRIPTION
## Done

-  Created a new alternate Placeholder implementation that can be sized useing CSS and has display as inline-block
- Moved the existing text-sizing implementation to a fallback with deprecation notes

## QA steps

- [ ]  Ensure the component is displayed correctly across all breakpoints
- [ ] Ensure the new visual is acceptable
- [ ] Ensure the dark mode is also clearly visible (you can check by adding the .is-dark class to the storybook body element
- [ ] Verify the visuals also work in the GenericTable loading state stories