### PR TITLE
feat(GenericTable): Column visibility controls and grouped selectable skeleton render support

### DIFF
--- a/src/lib/components/GenericTable/GenericTable.scss
+++ b/src/lib/components/GenericTable/GenericTable.scss
@@ -162,7 +162,7 @@
       }
 
       td.p-generic-table__group-chevron {
-        opacity: 40%;
+        opacity: 0.4;
       }
     }
   }

--- a/src/lib/components/GenericTable/GenericTable.scss
+++ b/src/lib/components/GenericTable/GenericTable.scss
@@ -64,6 +64,7 @@
         button {
           padding-top: 0;
           margin-bottom: 0;
+          color: var(--vf-color-text-default);
         }
 
         &:last-child {
@@ -158,6 +159,10 @@
       &:hover,
       &:focus-within {
         background: transparent !important;
+      }
+
+      td.p-generic-table__group-chevron {
+        opacity: 40%;
       }
     }
   }

--- a/src/lib/components/GenericTable/GenericTable.stories.tsx
+++ b/src/lib/components/GenericTable/GenericTable.stories.tsx
@@ -376,6 +376,20 @@ export const LoadingDefaultSkeleton: Story = {
 
 export const LoadingCustomSkeleton: Story = {
   name: "Loading (Custom skeleton)",
+  render: (args) => {
+    const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+    return (
+      <GenericTable
+        {...args}
+        selection={{
+          rowSelection: rowSelection,
+          rowSelectionLabelKey: "fqdn",
+          setRowSelection: setRowSelection,
+        }}
+      />
+    );
+  },
   args: {
     columns: [
       {
@@ -391,7 +405,7 @@ export const LoadingCustomSkeleton: Story = {
                 gap: "0.1rem",
               }}
             >
-              <Placeholder variant="block" width="100%" height="1.5rem" />
+              <Placeholder variant="block" width="70%" height="1.5rem" />
               <Placeholder
                 variant="block"
                 width="50%"
@@ -403,11 +417,46 @@ export const LoadingCustomSkeleton: Story = {
         },
       },
       {
-        ...machineColumns[1],
+        id: "status",
+        accessorKey: "status",
         meta: {
+          cellAriaLabel: (row) =>
+            `${row.original.status}, ${row.getLeafRows().length} machines`,
           skeleton: () => (
-            <Placeholder variant="block" width="50%" height="1.5rem" />
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.1rem",
+              }}
+            >
+              <Placeholder variant="block" width="10rem" height="1.5rem" />
+              <Placeholder
+                variant="block"
+                width="4rem"
+                height="1rem"
+                style={{ marginTop: "0.25rem" }}
+              />
+            </div>
           ),
+        },
+        cell: ({
+          row,
+          getValue,
+        }: {
+          row: Row<Machine>;
+          getValue: Getter<string>;
+        }) => {
+          return (
+            <div>
+              <div>
+                <strong>{getValue()}</strong>
+              </div>
+              <small className="u-text--muted">
+                {`${row.getLeafRows().length} machine${row.getLeafRows().length > 1 ? "s" : ""}`}
+              </small>
+            </div>
+          );
         },
       },
       machineColumns[2],
@@ -425,7 +474,19 @@ export const LoadingCustomSkeleton: Story = {
     data: [],
     isLoading: true,
     loadingVariant: "skeleton",
-    skeletonRowCount: 5,
+    skeletonRowCount: 2,
+    skeletonGroupCount: 2,
+    groupBy: ["status"],
+    filterCells: (row: Row<Machine>, column: Column<Machine>): boolean => {
+      if (row.getIsGrouped()) {
+        return ["status"].includes(column.id);
+      } else {
+        return !["status"].includes(column.id);
+      }
+    },
+    filterHeaders: (header: Header<Machine, unknown>): boolean =>
+      header.column.id !== "status",
+    showChevron: true,
   },
 };
 

--- a/src/lib/components/GenericTable/GenericTable.tsx
+++ b/src/lib/components/GenericTable/GenericTable.tsx
@@ -8,6 +8,7 @@ import {
   RefObject,
   SetStateAction,
   useMemo,
+  useState,
 } from "react";
 
 import {
@@ -21,6 +22,7 @@ import {
   Row,
   SortingState,
   useReactTable,
+  VisibilityState,
 } from "@tanstack/react-table";
 import classNames from "classnames";
 
@@ -33,7 +35,11 @@ import { useTableGrouping } from "@/lib/components/GenericTable/hooks/useTableGr
 import { useTableKeyboardNavigation } from "@/lib/components/GenericTable/hooks/useTableKeyboardNavigation";
 import { useTableScrollHeight } from "@/lib/components/GenericTable/hooks/useTableScrollHeight";
 import { useTableSorting } from "@/lib/components/GenericTable/hooks/useTableSorting";
-import { SelectionProps, GenericTableData } from "@/lib/components/GenericTable/types";
+import {
+  SelectionProps,
+  GenericTableData,
+  ColumnVisibilityProps,
+} from "@/lib/components/GenericTable/types";
 import { processColumnDefs } from "@/lib/components/GenericTable/utils/processColumnDefs";
 import { renderDataRows } from "@/lib/components/GenericTable/utils/renderDataRows";
 import { renderLoadingRows } from "@/lib/components/GenericTable/utils/renderLoadingRows";
@@ -53,14 +59,17 @@ type GenericTableProps<T extends GenericTableData> = {
   isLoading: boolean;
   loadingVariant?: "spinner" | "skeleton";
   skeletonRowCount?: number;
+  skeletonGroupCount?: number;
   noData?: ReactNode;
   pagination?: PaginationBarProps;
   pinGroup?: { value: string; isTop: boolean }[];
+  columnVisibility?: ColumnVisibilityProps;
   sorting?: ColumnSort[];
   selection?: SelectionProps<T>;
   setSorting?: Dispatch<SetStateAction<SortingState>>;
   showChevron?: boolean;
   variant?: "full-height" | "regular";
+  debug?: boolean;
 } & DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 
 /**
@@ -75,6 +84,8 @@ type GenericTableProps<T extends GenericTableData> = {
  * @param {Object} props - Component props
  * @param {string} [props.className] - Additional CSS class for the table wrapper
  * @param {ColumnDef<T, Partial<T>>[]} props.columns - Column definitions
+ * @param {ColumnVisibilityProps} [props.columnVisibility] - Controlled column visibility state and setter; when omitted, visibility is managed internally. See {@link ColumnVisibilityProps} for all sub-options
+ *  (columnVisibility, setColumnVisibility).
  * @param {RefObject<HTMLElement | null>} [props.containerRef] - Reference to container for size calculations
  * @param {T[]} props.data - Table data array
  * @param {(row: Row<T>, column: Column<T>) => boolean} [props.filterCells] - Function to filter which cells should be displayed
@@ -83,7 +94,8 @@ type GenericTableProps<T extends GenericTableData> = {
  * @param {string[]} [props.groupBy] - Column IDs to group rows by
  * @param {boolean} props.isLoading - Loading state to display placeholder content
  * @param {"spinner" | "skeleton"} [props.loadingVariant="spinner"] - Loading display style; "spinner" shows a single spinner row, "skeleton" renders skeletonRowCount pulsing skeleton rows using meta.skeleton per column when defined, falling back to a default Placeholder block
- * @param {number} [props.skeletonRowCount=10] - Number of skeleton rows to render when loadingVariant="skeleton"
+ * @param {number} [props.skeletonRowCount=10] - Number of skeleton rows to render per group (or total when ungrouped) when loadingVariant="skeleton"
+ * @param {number} [props.skeletonGroupCount=2] - Number of skeleton group rows to render when loadingVariant="skeleton" and groupBy is set
  * @param {ReactNode} [props.noData] - Content to display when no data is available
  * @param {PaginationBarProps} [props.pagination] - Pagination configuration
  * @param {{ value: string; isTop: boolean }[]} [props.pinGroup] - Group pinning configuration
@@ -93,6 +105,7 @@ type GenericTableProps<T extends GenericTableData> = {
  *   (filterSelectable, disabledSelectionTooltip, rowSelection, rowSelectionLabelKey, setRowSelection).
  * @param {boolean} [props.showChevron=false] - Show group row expansion state chevrons
  * @param {"full-height" | "regular"} [props.variant="full-height"] - Table layout variant
+ * @param {boolean} [props.debug] - React Table debug output
  *
  * @returns {ReactElement} - The rendered table component
  *
@@ -120,6 +133,7 @@ export const GenericTable = <T extends GenericTableData>({
   "aria-label": tableAriaLabel,
   className,
   columns: initialColumns,
+  columnVisibility: externalColumnVisibility,
   containerRef,
   data: initialData,
   filterCells = () => true,
@@ -129,6 +143,7 @@ export const GenericTable = <T extends GenericTableData>({
   isLoading,
   loadingVariant = "spinner",
   skeletonRowCount = 10,
+  skeletonGroupCount = 2,
   noData,
   pagination,
   pinGroup,
@@ -137,6 +152,7 @@ export const GenericTable = <T extends GenericTableData>({
   setSorting: setExternalSorting,
   showChevron = false,
   variant = "full-height",
+  debug = false,
   ...divProps
 }: GenericTableProps<T>): ReactElement => {
   const { grouping, setGrouping, groupedData } = useTableGrouping({
@@ -164,6 +180,14 @@ export const GenericTable = <T extends GenericTableData>({
     isLoading,
   });
 
+  const [internalColumnVisibility, setInternalColumnVisibility] =
+    useState<VisibilityState>({});
+  const columnVisibility =
+    externalColumnVisibility?.columnVisibility ?? internalColumnVisibility;
+  const setColumnVisibility =
+    externalColumnVisibility?.setColumnVisibility ??
+    setInternalColumnVisibility;
+
   // Add chevron and selection columns if needed
   const canSelect = !!selection;
   const columns = useMemo(
@@ -171,13 +195,12 @@ export const GenericTable = <T extends GenericTableData>({
       processColumnDefs({
         canSelect,
         initialColumns,
-        isLoading,
         groupBy,
         getSubRows,
         selection,
         showChevron,
       }),
-    [canSelect, initialColumns, isLoading, groupBy, getSubRows],
+    [canSelect, initialColumns, groupBy, getSubRows],
   );
 
   // Configure table
@@ -188,6 +211,7 @@ export const GenericTable = <T extends GenericTableData>({
       grouping,
       expanded,
       sorting,
+      columnVisibility,
       rowSelection: selection?.rowSelection,
     },
     manualPagination: true,
@@ -195,6 +219,7 @@ export const GenericTable = <T extends GenericTableData>({
     onExpandedChange: setExpanded,
     onSortingChange: setSorting,
     onGroupingChange: setGrouping,
+    onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: selection?.setRowSelection,
     manualSorting: true,
     enableSorting: true,
@@ -207,6 +232,7 @@ export const GenericTable = <T extends GenericTableData>({
     enableRowSelection: selection?.filterSelectable ?? canSelect,
     enableMultiRowSelection: selection?.filterSelectable ?? canSelect,
     getRowId: (originalRow) => originalRow.id.toString(),
+    debugAll: debug,
   });
 
   // Handle accessibility
@@ -284,8 +310,10 @@ export const GenericTable = <T extends GenericTableData>({
                 table,
                 columns,
                 filterHeaders,
+                filterCells,
                 loadingVariant,
                 skeletonRowCount,
+                skeletonGroupCount,
               })
             : renderDataRows({
                 table,

--- a/src/lib/components/GenericTable/components/TableCheckbox/TableCheckbox.tsx
+++ b/src/lib/components/GenericTable/components/TableCheckbox/TableCheckbox.tsx
@@ -33,8 +33,7 @@ const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
   const isAllSelected =
     selectableRows.length > 0 &&
     selectedSelectableRows.length === selectableRows.length;
-  const isIndeterminate =
-    selectedSelectableRows.length > 0 && !isAllSelected;
+  const isIndeterminate = selectedSelectableRows.length > 0 && !isAllSelected;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
@@ -76,8 +75,24 @@ const TableGroupCheckbox = <T,>({ row, ...props }: TableCheckboxProps<T>) => {
   const checkboxRef = useRef<HTMLInputElement>(null);
 
   if (!row) {
-    return null;
+    return (
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+      <label
+        className="p-checkbox--inline p-table-checkbox--group"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <input
+          className="p-checkbox__input"
+          disabled
+          type="checkbox"
+          {...props}
+        />
+        <span className="p-checkbox__label" />
+      </label>
+    );
   }
+
   const selectableSubRows = row.subRows.filter((subRow) =>
     subRow.getCanSelect(),
   );
@@ -123,15 +138,30 @@ const TableGroupCheckbox = <T,>({ row, ...props }: TableCheckboxProps<T>) => {
 
 const TableCheckbox = <T,>({
   row,
-  disabledTooltip,
+  disabledTooltip = "",
   isNested = false,
   ...props
 }: TableCheckboxProps<T> & {
-  disabledTooltip: string | ((row: Row<T>) => string);
-  isNested: boolean;
+  disabledTooltip?: string | ((row: Row<T>) => string);
+  isNested?: boolean;
 }): ReactElement | null => {
   if (!row) {
-    return null;
+    return (
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+      <label
+        className="p-checkbox--inline p-table-checkbox"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <input
+          className="p-checkbox__input"
+          disabled
+          type="checkbox"
+          {...props}
+        />
+        <span className="p-checkbox__label" />
+      </label>
+    );
   }
 
   const canSelect = row.getCanSelect();
@@ -145,8 +175,8 @@ const TableCheckbox = <T,>({
   const tooltipMessage = isNested
     ? "Selection is managed by the parent row"
     : !canSelect
-    ? disabledTooltipMessage
-    : false;
+      ? disabledTooltipMessage
+      : false;
 
   return (
     <Tooltip message={tooltipMessage} position="btm-right">

--- a/src/lib/components/GenericTable/types.ts
+++ b/src/lib/components/GenericTable/types.ts
@@ -1,6 +1,6 @@
 import { Dispatch, ReactNode, SetStateAction } from "react";
 
-import type { Row, RowData, RowSelectionState } from "@tanstack/react-table";
+import  { Row, RowData, RowSelectionState, VisibilityState } from "@tanstack/react-table";
 
 declare module "@tanstack/react-table" {
   // TData / TValue must match the upstream signature; unused in the body by design.
@@ -28,4 +28,9 @@ export type SelectionProps<T extends GenericTableData> = {
   rowSelectionLabelKey?: keyof T;
   rowSelection?: RowSelectionState;
   setRowSelection?: Dispatch<SetStateAction<RowSelectionState>>;
+};
+
+export type ColumnVisibilityProps = {
+  columnVisibility: VisibilityState;
+  setColumnVisibility: Dispatch<SetStateAction<VisibilityState>>;
 };

--- a/src/lib/components/GenericTable/utils/processColumnDefs.tsx
+++ b/src/lib/components/GenericTable/utils/processColumnDefs.tsx
@@ -12,7 +12,6 @@ import { SelectionProps, GenericTableData } from "@/lib/components/GenericTable/
 export const processColumnDefs = <T extends GenericTableData>({
   canSelect,
   initialColumns,
-  isLoading,
   groupBy,
   getSubRows,
   selection,
@@ -20,18 +19,12 @@ export const processColumnDefs = <T extends GenericTableData>({
 }: {
   canSelect: boolean;
   initialColumns: ColumnDef<T, Partial<T>>[];
-  isLoading: boolean;
   groupBy: string[] | undefined;
   getSubRows?: (originalRow: T, index: number) => T[] | undefined;
   selection?: SelectionProps<T>;
   showChevron: boolean;
 }): ColumnDef<T, Partial<T>>[] => {
   let processedColumns = [...initialColumns];
-
-  // Spinner loading doesn't render real rows — skip injecting interactive columns.
-  if (isLoading) {
-    return processedColumns;
-  }
 
   // Add selection columns if needed
   if (canSelect && selection) {

--- a/src/lib/components/GenericTable/utils/renderLoadingRows.tsx
+++ b/src/lib/components/GenericTable/utils/renderLoadingRows.tsx
@@ -1,25 +1,61 @@
-import { Spinner } from "@canonical/react-components";
-import { ColumnDef, Header, Table } from "@tanstack/react-table";
+import { ReactNode } from "react";
+
+import { Icon, ICONS, Spinner } from "@canonical/react-components";
+import { Column, ColumnDef, Header, Row, Table } from "@tanstack/react-table";
 import classNames from "classnames";
 
+import TableCheckbox from "@/lib/components/GenericTable/components/TableCheckbox";
 import { GenericTableData } from "@/lib/components/GenericTable/types";
 import { Placeholder } from "@/lib/elements/Placeholder/Placeholder";
+
+const renderInjectedCellContent = <T extends GenericTableData>(
+  header: Header<T, unknown>,
+  isGroupRow: boolean,
+) => {
+  const columnId = header.column.id;
+
+  if (columnId === "p-generic-table__group-chevron") {
+    return isGroupRow ? <Icon name={ICONS.chevronDown} /> : null;
+  }
+  if (columnId === "p-generic-table__group-select") {
+    return isGroupRow ? <TableCheckbox.Group aria-label="select group" /> : null;
+  }
+  if (columnId === "p-generic-table__select") {
+    return isGroupRow ? null : <TableCheckbox aria-label="select row" />;
+  }
+  return null;
+};
+
+// Calls filterCells with a minimal stub row so implementations that check
+// row.getIsGrouped() (or similar simple accessors) work without crashing.
+const applyFilterCells = <T extends GenericTableData>(
+  filterCells: (row: Row<T>, column: Column<T>) => boolean,
+  column: Column<T>,
+  isGroupRow: boolean,
+): boolean => {
+  const stubRow = { getIsGrouped: () => isGroupRow } as unknown as Row<T>;
+  return filterCells(stubRow, column);
+};
 
 export const renderLoadingRows = <T extends GenericTableData>({
   table,
   columns,
   filterHeaders,
+  filterCells,
   loadingVariant,
   skeletonRowCount,
+  skeletonGroupCount,
 }: {
   table: Table<T>;
   columns: ColumnDef<T, Partial<T>>[];
   filterHeaders: (header: Header<T, unknown>) => boolean;
+  filterCells: (row: Row<T>, column: Column<T>) => boolean;
   loadingVariant?: "skeleton" | "spinner";
   skeletonRowCount: number;
+  skeletonGroupCount: number;
 }) => {
-  const visibleHeaders =
-    table.getHeaderGroups()[0]?.headers.filter(filterHeaders) ?? [];
+  const allHeaders = table.getHeaderGroups()[0]?.headers ?? [];
+  const visibleHeaders = allHeaders.filter(filterHeaders);
 
   if (loadingVariant !== "skeleton") {
     return (
@@ -35,34 +71,83 @@ export const renderLoadingRows = <T extends GenericTableData>({
     );
   }
 
-  return Array.from({ length: skeletonRowCount }).map((_, rowIndex) => (
+  const isGrouped = allHeaders.some(
+    (h) =>
+      h.column.id === "p-generic-table__group-select" ||
+      h.column.id === "p-generic-table__group-chevron",
+  );
+
+  const renderRow = (key: string, rowIndex: number, isGroupRow: boolean) => (
     <tr
-      aria-rowindex={rowIndex + 2}
-      className="p-generic-table__skeleton-row"
-      key={`skel-${rowIndex}`}
+      aria-expanded={isGroupRow ? true : undefined}
+      aria-rowindex={rowIndex}
+      className={classNames({
+        "p-generic-table__group-row": isGroupRow,
+        "p-generic-table__individual-row": !isGroupRow,
+        "p-generic-table__skeleton-row": true,
+      })}
+      key={key}
       role="row"
     >
-      {visibleHeaders.map((header) => {
-        const meta = header.column.columnDef.meta;
-        const isInjectedColumn =
-          header.column.id.startsWith("p-generic-table__");
-        return (
-          <td
-            className={classNames(
-              "p-generic-table__skeleton-cell",
-              header.column.id,
-            )}
-            key={`skel-${rowIndex}-${header.id}`}
-            role="gridcell"
-          >
-            {isInjectedColumn ? null : meta?.skeleton ? (
-              meta.skeleton()
-            ) : (
-              <Placeholder variant="block" width="70%" height="1.5rem" />
-            )}
-          </td>
-        );
-      })}
+      {allHeaders
+        .filter((header) => {
+          const columnId = header.column.id;
+          // Mirror renderDataRows: group-specific columns always pass for group rows
+          if (
+            isGroupRow &&
+            (columnId === "p-generic-table__group-select" ||
+              columnId === "p-generic-table__group-chevron")
+          ) {
+            return true;
+          }
+          return applyFilterCells(
+            filterCells,
+            header.column as Column<T>,
+            isGroupRow,
+          );
+        })
+        .map((header) => {
+          const columnId = header.column.id;
+          const isInjected = columnId.startsWith("p-generic-table__");
+          const meta = header.column.columnDef.meta;
+
+          const content: ReactNode = isInjected ? (
+            renderInjectedCellContent(header, isGroupRow)
+          ) : meta?.skeleton ? (
+            meta.skeleton()
+          ) : (
+            <Placeholder variant="block" width="70%" height="1.5rem" />
+          );
+
+          return (
+            <td
+              className={classNames("p-generic-table__skeleton-cell", columnId)}
+              key={`${key}-${header.id}`}
+              role="gridcell"
+            >
+              {content}
+            </td>
+          );
+        })}
     </tr>
-  ));
+  );
+
+  if (!isGrouped) {
+    return Array.from({ length: skeletonRowCount }).map((_, i) =>
+      renderRow(`skel-${i}`, i + 2, false),
+    );
+  }
+
+  // Grouped skeleton: skeletonGroupCount groups × skeletonRowCount rows each
+  const rows = [];
+  let rowIndex = 1;
+
+  for (let g = 0; g < skeletonGroupCount; g++) {
+    rows.push(renderRow(`skel-group-${g}`, ++rowIndex, true));
+    for (let r = 0; r < skeletonRowCount; r++) {
+      rows.push(renderRow(`skel-${g}-${r}`, ++rowIndex, false));
+    }
+  }
+
+  return rows;
 };


### PR DESCRIPTION
## Done

- Added props for external column visibility control
- Introduced disabled checkbox render for selectable tables' skeleton renders
- Introduced skeleton group rows for grouped tables' skeleton renders

## QA steps

- [x] Ensure the component is displayed correctly across all breakpoints
- [x] Verify grouped and selectable tables display proper injected elements (chevron, selection checkboxes, indentation)
- [x] Verify the proper skeleton cell is rendered for group rows (specified by filterCells)
- [x] Verify skeleton loading state does not have accessible elements (try tabbing through the table, only the column headers should be interactive)